### PR TITLE
Show absolute filepath in lualine

### DIFF
--- a/lua/user/lualine.lua
+++ b/lua/user/lualine.lua
@@ -329,7 +329,12 @@ lualine.setup {
         --     return
         --         require('lspsaga.symbol.winbar').get_bar() ~= nil
         -- end } },
-        lualine_c = { 'filename' },
+        lualine_c = { 
+            {
+                'filename',
+                path = 3,  -- Show absolute path
+            }
+        },
         -- lualine_x = { diff, spaces, "encoding", filetype },
         -- lualine_x = { diff, lanuage_server, spaces, filetype },
         -- lualine_x = { lanuage_server, spaces, filetype },


### PR DESCRIPTION
Configure lualine to display the bottom filepath as absolute.

---
<a href="https://cursor.com/background-agent?bcId=bc-3ef1fdf1-03e6-4df1-a4f9-27452234059e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3ef1fdf1-03e6-4df1-a4f9-27452234059e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>