### PR TITLE
Display code diagnostics in a buffer

### DIFF
--- a/DIAGNOSTICS_DISPLAY_PLUGIN.md
+++ b/DIAGNOSTICS_DISPLAY_PLUGIN.md
@@ -1,11 +1,12 @@
-# Diagnostics Display Plugin
+# COC Diagnostics Display Plugin
 
-A Neovim plugin that displays diagnostics for the current line or current file in a nicely formatted floating window.
+A Neovim plugin that displays COC.nvim diagnostics for the current line or current file in a nicely formatted floating window.
 
 ## Features
 
-- **Current Line Diagnostics**: Shows all diagnostics for the line where your cursor is positioned
-- **Current File Diagnostics**: Shows all diagnostics for the entire current file
+- **COC.nvim Integration**: Uses COC.nvim diagnostics exclusively
+- **Current Line Diagnostics**: Shows all COC diagnostics for the line where your cursor is positioned
+- **Current File Diagnostics**: Shows all COC diagnostics for the entire current file
 - **Beautiful UI**: Floating window with rounded borders and proper highlighting
 - **Organized Display**: Diagnostics are grouped by severity (Error, Warning, Info, Hint)
 - **Detailed Information**: Shows line numbers, columns, diagnostic codes, and sources
@@ -24,11 +25,11 @@ A Neovim plugin that displays diagnostics for the current line or current file i
 
 ## Display Format
 
-The plugin shows diagnostics in a structured format:
+The plugin shows COC diagnostics in a structured format:
 
 ```
-  Current Line Diagnostics
-────────────────────────────
+  Current Line Diagnostics (COC)
+─────────────────────────────────
 
 E Error (2)
 ───────────
@@ -53,17 +54,23 @@ require('user.diagnostics_display').setup({
   height = 20,              -- Default height
   max_width = 120,          -- Maximum width
   max_height = 30,          -- Maximum height
-  title_current_line = "  Current Line Diagnostics",
-  title_current_file = "  Current File Diagnostics",
+  title_current_line = "  Current Line Diagnostics (COC)",
+  title_current_file = "  Current File Diagnostics (COC)",
 })
 ```
+
+## Requirements
+
+- COC.nvim must be installed and configured
+- COC language servers must be set up for your file types
 
 ## Integration
 
 The plugin integrates with:
-- Native Neovim LSP diagnostics
+- **COC.nvim diagnostics exclusively** - uses `CocAction('diagnosticList')`
 - Which-key for keymap descriptions
 - Your existing diagnostic icons configuration
+- COC highlight groups for proper theming
 
 ## Installation
 

--- a/DIAGNOSTICS_DISPLAY_PLUGIN.md
+++ b/DIAGNOSTICS_DISPLAY_PLUGIN.md
@@ -19,6 +19,7 @@ A Neovim plugin that displays COC.nvim diagnostics for the current line or curre
 | `<leader>dl` | `show_current_line_diagnostics()` | Show diagnostics for current line |
 | `<leader>df` | `show_current_file_diagnostics()` | Show diagnostics for current file |
 | `<leader>dd` | `debug()` | Debug COC diagnostics (troubleshooting) |
+| `<leader>dt` | `test_line_numbers()` | Test line number matching (temporary) |
 
 ### Within the diagnostic window:
 - `q` or `<Esc>` - Close the window

--- a/DIAGNOSTICS_DISPLAY_PLUGIN.md
+++ b/DIAGNOSTICS_DISPLAY_PLUGIN.md
@@ -18,10 +18,11 @@ A Neovim plugin that displays COC.nvim diagnostics for the current line or curre
 |--------|----------|-------------|
 | `<leader>dl` | `show_current_line_diagnostics()` | Show diagnostics for current line |
 | `<leader>df` | `show_current_file_diagnostics()` | Show diagnostics for current file |
+| `<leader>dd` | `debug()` | Debug COC diagnostics (troubleshooting) |
 
 ### Within the diagnostic window:
 - `q` or `<Esc>` - Close the window
-- `<CR>` - Close the window (future: jump to diagnostic)
+- `<CR>` - Navigate to the diagnostic under cursor (with visual flash)
 
 ## Display Format
 
@@ -87,4 +88,6 @@ The plugin is already integrated into this Neovim configuration. It's loaded in 
 
 1. **Check current line**: Place cursor on a line with diagnostics and press `<leader>dl`
 2. **Check entire file**: Press `<leader>df` to see all diagnostics in the current file
-3. **Quick overview**: The window shows diagnostics grouped by severity for easy scanning
+3. **Navigate to diagnostic**: In the diagnostic window, press `<CR>` on any diagnostic line to jump to it
+4. **Debug issues**: If current line diagnostics aren't working, use `<leader>dd` to debug COC diagnostic structure
+5. **Quick overview**: The window shows diagnostics grouped by severity for easy scanning

--- a/DIAGNOSTICS_DISPLAY_PLUGIN.md
+++ b/DIAGNOSTICS_DISPLAY_PLUGIN.md
@@ -1,0 +1,83 @@
+# Diagnostics Display Plugin
+
+A Neovim plugin that displays diagnostics for the current line or current file in a nicely formatted floating window.
+
+## Features
+
+- **Current Line Diagnostics**: Shows all diagnostics for the line where your cursor is positioned
+- **Current File Diagnostics**: Shows all diagnostics for the entire current file
+- **Beautiful UI**: Floating window with rounded borders and proper highlighting
+- **Organized Display**: Diagnostics are grouped by severity (Error, Warning, Info, Hint)
+- **Detailed Information**: Shows line numbers, columns, diagnostic codes, and sources
+- **Easy Navigation**: Simple keymaps to close the window
+
+## Keymaps
+
+| Keymap | Function | Description |
+|--------|----------|-------------|
+| `<leader>dl` | `show_current_line_diagnostics()` | Show diagnostics for current line |
+| `<leader>df` | `show_current_file_diagnostics()` | Show diagnostics for current file |
+
+### Within the diagnostic window:
+- `q` or `<Esc>` - Close the window
+- `<CR>` - Close the window (future: jump to diagnostic)
+
+## Display Format
+
+The plugin shows diagnostics in a structured format:
+
+```
+  Current Line Diagnostics
+────────────────────────────
+
+E Error (2)
+───────────
+  E Error: Expected ';' after expression (ts2304) [typescript]
+  E Error: Variable 'foo' is not defined (undefined-variable) [eslint]
+
+W Warning (1)
+─────────────
+  W Warning: Line 45, Col 12: Unused variable 'bar' [eslint]
+
+Total: 3 diagnostics
+```
+
+## Configuration
+
+The plugin can be configured by calling the setup function:
+
+```lua
+require('user.diagnostics_display').setup({
+  border = "rounded",        -- Border style for floating window
+  width = 80,               -- Default width
+  height = 20,              -- Default height
+  max_width = 120,          -- Maximum width
+  max_height = 30,          -- Maximum height
+  title_current_line = "  Current Line Diagnostics",
+  title_current_file = "  Current File Diagnostics",
+})
+```
+
+## Integration
+
+The plugin integrates with:
+- Native Neovim LSP diagnostics
+- Which-key for keymap descriptions
+- Your existing diagnostic icons configuration
+
+## Installation
+
+The plugin is already integrated into this Neovim configuration. It's loaded in `init.lua` and keymaps are defined in both `keymaps.lua` and `whichkey.lua`.
+
+## Files
+
+- `lua/user/diagnostics_display.lua` - Main plugin code
+- Keymaps added to `lua/user/keymaps.lua`
+- Which-key integration in `lua/user/whichkey.lua`
+- Loaded in `init.lua`
+
+## Usage Examples
+
+1. **Check current line**: Place cursor on a line with diagnostics and press `<leader>dl`
+2. **Check entire file**: Press `<leader>df` to see all diagnostics in the current file
+3. **Quick overview**: The window shows diagnostics grouped by severity for easy scanning

--- a/init.lua
+++ b/init.lua
@@ -42,6 +42,7 @@ require "user.colorizer"
 require "user.functions" 
 require "user.surround"
 require "user.nvim_transparent"
+require "user.diagnostics_display"
 
 -- Setup buffer browser (lazy loaded on keymap)
 vim.keymap.set("n", "<leader>bb", function()

--- a/lua/user/diagnostics_display.lua
+++ b/lua/user/diagnostics_display.lua
@@ -1,0 +1,263 @@
+local M = {}
+
+local icons = require("user.icons")
+
+-- Configuration
+local config = {
+  border = "rounded",
+  width = 80,
+  height = 20,
+  title_current_line = "  Current Line Diagnostics",
+  title_current_file = "  Current File Diagnostics",
+  max_width = 120,
+  max_height = 30,
+}
+
+-- Diagnostic severity mapping
+local severity_map = {
+  [vim.diagnostic.severity.ERROR] = {
+    icon = icons.diagnostics.Error,
+    name = "Error",
+    hl = "DiagnosticError"
+  },
+  [vim.diagnostic.severity.WARN] = {
+    icon = icons.diagnostics.Warning,
+    name = "Warning", 
+    hl = "DiagnosticWarn"
+  },
+  [vim.diagnostic.severity.INFO] = {
+    icon = icons.diagnostics.Information,
+    name = "Info",
+    hl = "DiagnosticInfo"
+  },
+  [vim.diagnostic.severity.HINT] = {
+    icon = icons.diagnostics.Hint,
+    name = "Hint",
+    hl = "DiagnosticHint"
+  }
+}
+
+-- Helper function to format diagnostic message
+local function format_diagnostic(diagnostic, show_line_info)
+  local severity_info = severity_map[diagnostic.severity] or {
+    icon = "?", 
+    name = "Unknown", 
+    hl = "Normal"
+  }
+  
+  local line_info = ""
+  if show_line_info and diagnostic.lnum then
+    line_info = string.format("Line %d, Col %d: ", diagnostic.lnum + 1, diagnostic.col + 1)
+  end
+  
+  local source_info = ""
+  if diagnostic.source then
+    source_info = string.format(" [%s]", diagnostic.source)
+  end
+  
+  local code_info = ""
+  if diagnostic.code then
+    code_info = string.format(" (%s)", diagnostic.code)
+  end
+  
+  return {
+    icon = severity_info.icon,
+    severity = severity_info.name,
+    hl = severity_info.hl,
+    line_info = line_info,
+    message = diagnostic.message,
+    source_info = source_info,
+    code_info = code_info,
+    full_text = string.format("%s %s: %s%s%s%s", 
+      severity_info.icon, 
+      severity_info.name,
+      line_info,
+      diagnostic.message,
+      code_info,
+      source_info
+    )
+  }
+end
+
+-- Helper function to create buffer content
+local function create_buffer_content(diagnostics, title, show_line_info)
+  local content = {}
+  local highlights = {}
+  
+  -- Add title
+  table.insert(content, title)
+  table.insert(content, string.rep("─", #title))
+  table.insert(content, "")
+  
+  if #diagnostics == 0 then
+    table.insert(content, "  No diagnostics found")
+    return content, highlights
+  end
+  
+  -- Group diagnostics by severity
+  local grouped = {
+    [vim.diagnostic.severity.ERROR] = {},
+    [vim.diagnostic.severity.WARN] = {},
+    [vim.diagnostic.severity.INFO] = {},
+    [vim.diagnostic.severity.HINT] = {}
+  }
+  
+  for _, diagnostic in ipairs(diagnostics) do
+    table.insert(grouped[diagnostic.severity], diagnostic)
+  end
+  
+  -- Add diagnostics by severity (errors first)
+  for _, severity in ipairs({
+    vim.diagnostic.severity.ERROR,
+    vim.diagnostic.severity.WARN, 
+    vim.diagnostic.severity.INFO,
+    vim.diagnostic.severity.HINT
+  }) do
+    local group = grouped[severity]
+    if #group > 0 then
+      local severity_info = severity_map[severity]
+      local section_title = string.format("%s %s (%d)", 
+        severity_info.icon, 
+        severity_info.name, 
+        #group
+      )
+      
+      table.insert(content, section_title)
+      table.insert(highlights, {
+        line = #content - 1,
+        col_start = 0,
+        col_end = #section_title,
+        hl_group = severity_info.hl
+      })
+      
+      table.insert(content, string.rep("─", #section_title))
+      table.insert(content, "")
+      
+      for _, diagnostic in ipairs(group) do
+        local formatted = format_diagnostic(diagnostic, show_line_info)
+        
+        -- Add the main diagnostic line
+        local main_line = string.format("  %s", formatted.full_text)
+        table.insert(content, main_line)
+        
+        -- Highlight the icon and severity
+        table.insert(highlights, {
+          line = #content - 1,
+          col_start = 2,
+          col_end = 2 + #formatted.icon + 1 + #formatted.severity,
+          hl_group = formatted.hl
+        })
+        
+        -- Add empty line for spacing
+        table.insert(content, "")
+      end
+    end
+  end
+  
+  -- Add summary
+  table.insert(content, "")
+  table.insert(content, string.rep("─", 40))
+  local summary = string.format("Total: %d diagnostics", #diagnostics)
+  table.insert(content, summary)
+  
+  return content, highlights
+end
+
+-- Helper function to create and show the diagnostic buffer
+local function show_diagnostic_buffer(diagnostics, title, show_line_info)
+  local content, highlights = create_buffer_content(diagnostics, title, show_line_info)
+  
+  -- Calculate window dimensions
+  local max_line_length = 0
+  for _, line in ipairs(content) do
+    if #line > max_line_length then
+      max_line_length = #line
+    end
+  end
+  
+  local width = math.min(math.max(max_line_length + 4, config.width), config.max_width)
+  local height = math.min(math.max(#content + 2, config.height), config.max_height)
+  
+  -- Create buffer
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_option(buf, "modifiable", true)
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, content)
+  vim.api.nvim_buf_set_option(buf, "modifiable", false)
+  vim.api.nvim_buf_set_option(buf, "bufhidden", "wipe")
+  vim.api.nvim_buf_set_option(buf, "filetype", "diagnostics")
+  
+  -- Apply highlights
+  local ns_id = vim.api.nvim_create_namespace("diagnostics_display")
+  for _, hl in ipairs(highlights) do
+    vim.api.nvim_buf_add_highlight(buf, ns_id, hl.hl_group, hl.line, hl.col_start, hl.col_end)
+  end
+  
+  -- Calculate window position (center of screen)
+  local ui = vim.api.nvim_list_uis()[1]
+  local win_row = math.floor((ui.height - height) / 2)
+  local win_col = math.floor((ui.width - width) / 2)
+  
+  -- Create window
+  local win_opts = {
+    relative = "editor",
+    width = width,
+    height = height,
+    row = win_row,
+    col = win_col,
+    style = "minimal",
+    border = config.border,
+    title = title,
+    title_pos = "center",
+  }
+  
+  local win = vim.api.nvim_open_win(buf, true, win_opts)
+  
+  -- Set window options
+  vim.api.nvim_win_set_option(win, "wrap", true)
+  vim.api.nvim_win_set_option(win, "cursorline", true)
+  
+  -- Set keymaps for the buffer
+  local opts = { noremap = true, silent = true, buffer = buf }
+  vim.keymap.set("n", "q", "<cmd>close<cr>", opts)
+  vim.keymap.set("n", "<Esc>", "<cmd>close<cr>", opts)
+  vim.keymap.set("n", "<CR>", function()
+    local line_num = vim.api.nvim_win_get_cursor(win)[1]
+    -- Try to find diagnostic info in the current line to jump to it
+    -- This is a simple implementation - could be enhanced
+    vim.cmd("close")
+  end, opts)
+  
+  return buf, win
+end
+
+-- Show diagnostics for current line
+function M.show_current_line_diagnostics()
+  local line = vim.api.nvim_win_get_cursor(0)[1] - 1
+  local diagnostics = vim.diagnostic.get(0, { lnum = line })
+  
+  show_diagnostic_buffer(
+    diagnostics, 
+    config.title_current_line, 
+    false -- don't show line info since it's all the same line
+  )
+end
+
+-- Show diagnostics for current file
+function M.show_current_file_diagnostics()
+  local diagnostics = vim.diagnostic.get(0)
+  
+  show_diagnostic_buffer(
+    diagnostics, 
+    config.title_current_file, 
+    true -- show line info since diagnostics are from different lines
+  )
+end
+
+-- Setup function to configure the plugin
+function M.setup(user_config)
+  if user_config then
+    config = vim.tbl_deep_extend("force", config, user_config)
+  end
+end
+
+return M

--- a/lua/user/keymaps.lua
+++ b/lua/user/keymaps.lua
@@ -269,5 +269,6 @@ end, { desc = 'Live grep in base' })
 keymap("n", "<leader>dl", "<cmd>lua require('user.diagnostics_display').show_current_line_diagnostics()<cr>", opts)
 keymap("n", "<leader>df", "<cmd>lua require('user.diagnostics_display').show_current_file_diagnostics()<cr>", opts)
 keymap("n", "<leader>dd", "<cmd>lua require('user.diagnostics_display').debug()<cr>", opts)
+keymap("n", "<leader>dt", "<cmd>lua require('user.diagnostics_display').test_line_numbers()<cr>", opts)
 
 return M

--- a/lua/user/keymaps.lua
+++ b/lua/user/keymaps.lua
@@ -265,4 +265,8 @@ vim.keymap.set('n', '<leader>gb', function()
   }
 end, { desc = 'Live grep in base' })
 
+-- Diagnostic Display Plugin Keymaps
+keymap("n", "<leader>dl", "<cmd>lua require('user.diagnostics_display').show_current_line_diagnostics()<cr>", opts)
+keymap("n", "<leader>df", "<cmd>lua require('user.diagnostics_display').show_current_file_diagnostics()<cr>", opts)
+
 return M

--- a/lua/user/keymaps.lua
+++ b/lua/user/keymaps.lua
@@ -268,5 +268,6 @@ end, { desc = 'Live grep in base' })
 -- Diagnostic Display Plugin Keymaps
 keymap("n", "<leader>dl", "<cmd>lua require('user.diagnostics_display').show_current_line_diagnostics()<cr>", opts)
 keymap("n", "<leader>df", "<cmd>lua require('user.diagnostics_display').show_current_file_diagnostics()<cr>", opts)
+keymap("n", "<leader>dd", "<cmd>lua require('user.diagnostics_display').debug()<cr>", opts)
 
 return M

--- a/lua/user/whichkey.lua
+++ b/lua/user/whichkey.lua
@@ -349,6 +349,11 @@ which_key.add {
     "<cmd>lua require('user.diagnostics_display').show_current_file_diagnostics()<cr>",
     desc = "File Diagnostics",
   },
+  {
+    "<leader>dd",
+    "<cmd>lua require('user.diagnostics_display').debug()<cr>",
+    desc = "Debug Diagnostics",
+  },
 
   -- Git
   {

--- a/lua/user/whichkey.lua
+++ b/lua/user/whichkey.lua
@@ -338,6 +338,18 @@ which_key.add {
     desc = "Find Files (with preview)",
   },
 
+  -- Diagnostics
+  {
+    "<leader>dl",
+    "<cmd>lua require('user.diagnostics_display').show_current_line_diagnostics()<cr>",
+    desc = "Line Diagnostics",
+  },
+  {
+    "<leader>df",
+    "<cmd>lua require('user.diagnostics_display').show_current_file_diagnostics()<cr>",
+    desc = "File Diagnostics",
+  },
+
   -- Git
   {
     "<leader>gg",


### PR DESCRIPTION
Add a Neovim plugin to display diagnostics for the current line or file in a formatted floating window.

---
<a href="https://cursor.com/background-agent?bcId=bc-b6b54870-08b6-468f-bc38-541ce5974f5f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b6b54870-08b6-468f-bc38-541ce5974f5f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>