### PR TITLE
Delay file search until typing

### DIFF
--- a/lua/user/telescope.lua
+++ b/lua/user/telescope.lua
@@ -205,6 +205,7 @@ telescope.setup {
             path_display = { "smart" }, -- Smart path display for better performance
             follow = false, -- Don't follow symlinks for better performance
             hidden = true,
+            disable_initial_results = true, -- Don't show any files until user starts typing
         },
         
         git_files = {


### PR DESCRIPTION
Add `disable_initial_results` to Telescope's `find_files` configuration to prevent initial file display.

---
<a href="https://cursor.com/background-agent?bcId=bc-96a78315-6493-4af5-b701-f69d5543f2dc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-96a78315-6493-4af5-b701-f69d5543f2dc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>