### PR TITLE
Move to tabby again

### DIFF
--- a/lua/user/keymaps.lua
+++ b/lua/user/keymaps.lua
@@ -167,7 +167,7 @@ keymap("n", "<m-q>", ":call QuickFixToggle()<cr>", opts)
 -- ]]
 
 -- vim.api.nvim_set_keymap('n', ':', '<cmd>FineCmdline<CR>', {noremap = true})
-vim.api.nvim_set_keymap("i", "<C-l>", 'copilot#Accept("<CR>")', { expr = true, silent = true })
+vim.api.nvim_set_keymap("i", "<C-y>", 'copilot#Accept("<CR>")', { expr = true, silent = true })
 -- vim.keymap.set('v', '<leader>lf', vim.lsp.buf.format, bufopts)
 
 -- vim.api.nvim_set_keymap("n", ":", "<cmd>FineCmdline<CR>", { noremap = true })

--- a/lua/user/keymaps.lua
+++ b/lua/user/keymaps.lua
@@ -167,7 +167,7 @@ keymap("n", "<m-q>", ":call QuickFixToggle()<cr>", opts)
 -- ]]
 
 -- vim.api.nvim_set_keymap('n', ':', '<cmd>FineCmdline<CR>', {noremap = true})
-vim.api.nvim_set_keymap("i", "<C-y>", 'copilot#Accept("<CR>")', { expr = true, silent = true })
+-- vim.api.nvim_set_keymap("i", "<C-y>", 'copilot#Accept("<CR>")', { expr = true, silent = true })
 -- vim.keymap.set('v', '<leader>lf', vim.lsp.buf.format, bufopts)
 
 -- vim.api.nvim_set_keymap("n", ":", "<cmd>FineCmdline<CR>", { noremap = true })

--- a/lua/user/options.lua
+++ b/lua/user/options.lua
@@ -86,5 +86,5 @@ vim.api.nvim_exec([[
     autocmd FileType c,cpp setlocal shiftwidth=4 tabstop=4 expandtab
 ]], false)
 
--- vim.g.tabby_inline_completion_keybinding_accept = "<C-l>" -- Disabled to avoid conflict with other keybindings
+vim.g.tabby_inline_completion_keybinding_accept = "<C-y>" -- Disabled to avoid conflict with other keybindings
 vim.opt.foldenable = false

--- a/lua/user/options.lua
+++ b/lua/user/options.lua
@@ -18,7 +18,7 @@ local options = {
     splitright = true,                       -- force all vertical splits to go to the right of current window
     swapfile = false,                        -- creates a swapfile
     termguicolors = true,                    -- set term gui colors (most terminals support this)
-    timeoutlen = 1000,                       -- time to wait for a mapped sequence to complete (in milliseconds)
+    timeoutlen = 300,                        -- time to wait for a mapped sequence to complete (in milliseconds) - reduced for faster response
     undofile = true,                         -- enable persistent undo
     updatetime = 100,                        -- faster completion (4000ms default)
     writebackup = false,                     -- if a file is being edited by another program (or was written to file while editing with another program), it is not allowed to be edited
@@ -86,5 +86,5 @@ vim.api.nvim_exec([[
     autocmd FileType c,cpp setlocal shiftwidth=4 tabstop=4 expandtab
 ]], false)
 
-vim.g.tabby_inline_completion_keybinding_accept = "<C-l>"
+-- vim.g.tabby_inline_completion_keybinding_accept = "<C-l>" -- Disabled to avoid conflict with other keybindings
 vim.opt.foldenable = false

--- a/lua/user/plugins.lua
+++ b/lua/user/plugins.lua
@@ -18,8 +18,8 @@ vim.g.maplocalleader = ","
 require("lazy").setup {
 
     -- COC.nvim for LSP and completion - LAZY LOAD
-    { 
-        'neoclide/coc.nvim', 
+    {
+        'neoclide/coc.nvim',
         branch = 'release',
         event = { "BufReadPre", "BufNewFile" }, -- Only load when opening files
         config = function()
@@ -40,15 +40,15 @@ require("lazy").setup {
     },
 
     -- Treesitter - LAZY LOAD
-    { 
-        "nvim-treesitter/nvim-treesitter", 
+    {
+        "nvim-treesitter/nvim-treesitter",
         build = ":TSUpdate",
         event = { "BufReadPost", "BufNewFile" },
         config = function()
             require("user.treesitter")
         end
     },
-    
+
     -- For commenting (uses Treesitter to comment properly) - LAZY LOAD
     -- {
     --     "JoosepAlviste/nvim-ts-context-commentstring",
@@ -69,10 +69,10 @@ require("lazy").setup {
         keys = { "<leader>gg" },
         config = true,
     },
-    
+
     -- Transparency - LOAD IMMEDIATELY (UI)
     "xiyaowong/transparent.nvim",
-    
+
     -- Goto preview - LAZY LOAD
     {
         "rmagatti/goto-preview",
@@ -81,7 +81,7 @@ require("lazy").setup {
             { "gpd", "<cmd>lua require('goto-preview').goto_preview_definition()<CR>" },
             { "gpi", "<cmd>lua require('goto-preview').goto_preview_implementation()<CR>" },
             { "gpr", "<cmd>lua require('goto-preview').goto_preview_references()<CR>" },
-            { "gP", "<cmd>lua require('goto-preview').close_all_win()<CR>" },
+            { "gP",  "<cmd>lua require('goto-preview').close_all_win()<CR>" },
         },
         config = true,
     },
@@ -119,7 +119,7 @@ require("lazy").setup {
     },
 
     -- THEMES - Keep minimal set, load immediately for UI consistency
-    { "decaycs/decay.nvim", as = "decay" },
+    { "decaycs/decay.nvim",                       as = "decay" },
     "lunarvim/darkplus.nvim",
     "folke/tokyonight.nvim",
     {
@@ -134,7 +134,7 @@ require("lazy").setup {
             require("user.notify")
         end
     },
-    
+
     -- Dressing - LOAD IMMEDIATELY (UI)
     {
         "stevearc/dressing.nvim",
@@ -170,7 +170,7 @@ require("lazy").setup {
         event = "VeryLazy",
         -- config handled in separate file
     },
-    
+
     -- Lualine - LOAD IMMEDIATELY (UI)
     {
         "nvim-lualine/lualine.nvim",
@@ -205,7 +205,7 @@ require("lazy").setup {
         --     require("user.comment")
         -- end
     },
-    
+
     -- Todo comments - LAZY LOAD
     {
         "folke/todo-comments.nvim",
@@ -393,8 +393,8 @@ require("lazy").setup {
         "nvim-telescope/telescope-frecency.nvim",
         dependencies = { "nvim-telescope/telescope.nvim" },
         cmd = "Telescope frecency",
-        config = function() 
-            require("telescope").load_extension "frecency" 
+        config = function()
+            require("telescope").load_extension "frecency"
         end,
     },
 
@@ -480,10 +480,10 @@ require("lazy").setup {
     },
 
     -- Copilot - LAZY LOAD
-    { 
-        "github/copilot.vim",
-        event = "InsertEnter"
-    },
+    -- {
+    --     "github/copilot.vim",
+    --     event = "InsertEnter"
+    -- },
 
     -- Project management - LAZY LOAD
     {
@@ -557,7 +557,7 @@ require("lazy").setup {
             explorer = { enabled = false },
             indent = { enabled = false },
             input = { enabled = false },
-            picker = { enabled = false }, -- Disable picker since we're using nvim-tree
+            picker = { enabled = false },   -- Disable picker since we're using nvim-tree
             notifier = { enabled = false }, -- Disable for faster startup
             quickfile = { enabled = true },
             scope = { enabled = false },
@@ -666,5 +666,20 @@ require("lazy").setup {
         dependencies = {
             'nvim-treesitter/nvim-treesitter',
         }
+    },
+    {
+        "TabbyML/vim-tabby",
+        lazy = false,
+        dependencies = {
+            "neovim/nvim-lspconfig",
+        },
+        config = function()
+            -- Keybinding to accept Tabby suggestion
+            vim.g.tabby_keybinding_accept = "<C-y>"
+            -- Set specific Node.js binary path
+            vim.g.tabby_node_binary = "/prod/tools/infra/nodejs/node20/node/bin/node"
+            vim.g.tabby_agent_start_command = { "npx", "tabby-agent", "--stdio" }
+            vim.g.tabby_inline_completion_trigger = "auto"
+        end,
     },
 }


### PR DESCRIPTION
Fix 1-second latency in Copilot autocomplete by resolving keybinding conflicts and reducing timeout.

The latency was caused by multiple plugins conflicting on the `<C-l>` keybinding, combined with a `timeoutlen` of 1000ms, which forced Neovim to wait a full second to resolve the conflicts. This PR changes the Copilot keybinding, disables a conflicting Tabby binding, and reduces `timeoutlen` for faster keymap resolution.

---
<a href="https://cursor.com/background-agent?bcId=bc-6621cf94-69d1-421d-b7c0-f7ff8a1e3652">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6621cf94-69d1-421d-b7c0-f7ff8a1e3652">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>