### PR TITLE
Normalize all picker paths to workspace relative

### DIFF
--- a/lua/user/keymaps.lua
+++ b/lua/user/keymaps.lua
@@ -175,6 +175,16 @@ keymap("n", "<m-q>", ":call QuickFixToggle()<cr>", opts)
 vim.g.copilot_no_tab_map = true
 
 
+-- Custom path display function to show relative paths from workspace root
+local function relative_path_display(opts, path)
+    local cwd = vim.fn.getcwd()
+    local relative_path = vim.fn.fnamemodify(path, ":~:.")
+    if path:sub(1, #cwd) == cwd then
+        relative_path = path:sub(#cwd + 2) -- +2 to remove the leading slash
+    end
+    return relative_path
+end
+
 -- Helper functions to fetch the current scope and set `search_dirs`
 _G.find_files = function()
     local current_path = vim.fn.expand "%:p:h"
@@ -184,7 +194,7 @@ _G.find_files = function()
         search_dirs = { relative_path },
         debounce = 50,
         results_limit = 100,
-        path_display = { "smart" },
+        path_display = relative_path_display,
         previewer = false,
         follow = false,
     }
@@ -197,7 +207,7 @@ _G.live_grep = function()
         search_dirs = { relative_path },
         debounce = 50,
         results_limit = 100,
-        path_display = { "smart" },
+        path_display = relative_path_display,
         previewer = false,
     }
 end

--- a/lua/user/telescope.lua
+++ b/lua/user/telescope.lua
@@ -9,6 +9,16 @@ local lga_actions = require "telescope-live-grep-args.actions"
 local icons = require "user.icons"
 local themes = require "user.telescope.user_themes"
 
+-- Custom path display function to show relative paths from workspace root
+local function relative_path_display(opts, path)
+    local cwd = vim.fn.getcwd()
+    local relative_path = vim.fn.fnamemodify(path, ":~:.")
+    if path:sub(1, #cwd) == cwd then
+        relative_path = path:sub(#cwd + 2) -- +2 to remove the leading slash
+    end
+    return relative_path
+end
+
 telescope.setup {
     defaults = {
         wrap_results = true,
@@ -69,7 +79,7 @@ telescope.setup {
         prompt_prefix = "> ",
         selection_caret = "> ",
         entry_prefix = " ",
-        path_display = { "absolute" }, -- Changed from absolute to absolute for better performance
+        path_display = relative_path_display,
 
         color_devicons = false, -- Disabled to avoid nerd fonts
 
@@ -170,7 +180,7 @@ telescope.setup {
     pickers = {
         live_grep = {
             find_command = { "rg", "--no-heading", "--with-filename", "--line-number", "--column", "--smart-case" },
-            path_display = { "absolute" },
+            path_display = relative_path_display,
             previewer = false,
             debounce = 50, -- Reduced from 100 for faster response
             results_limit = 100, -- Added limit for faster results
@@ -202,7 +212,7 @@ telescope.setup {
             previewer = false,
             debounce = 50, -- Added debouncing for better performance
             results_limit = 150, -- Added limit for faster initial display
-            path_display = { "absolute" }, -- absolute path display for better performance
+            path_display = relative_path_display,
             follow = false, -- Don't follow symlinks for better performance
             hidden = true,
         },
@@ -285,7 +295,7 @@ telescope.setup {
             auto_quoting = false,
             find_command = "rg",
             theme = "ivy",
-            path_display = { "absolute" },
+            path_display = relative_path_display,
             debounce = 50,
             results_limit = 100,
         },

--- a/lua/user/telescope/user_themes.lua
+++ b/lua/user/telescope/user_themes.lua
@@ -1,5 +1,15 @@
 local themes = {}
 
+-- Custom path display function to show relative paths from workspace root
+local function relative_path_display(opts, path)
+  local cwd = vim.fn.getcwd()
+  local relative_path = vim.fn.fnamemodify(path, ":~:.")
+  if path:sub(1, #cwd) == cwd then
+    relative_path = path:sub(#cwd + 2) -- +2 to remove the leading slash
+  end
+  return relative_path
+end
+
 function themes.get_ivy_vertical(opts)
   opts = opts or {}
 
@@ -16,7 +26,7 @@ function themes.get_ivy_vertical(opts)
     },
 
     wrap_results = true,
-    path_display = { "absolute" },
+    path_display = relative_path_display,
 
     border = true,
     borderchars = {


### PR DESCRIPTION
Configure Telescope to display full relative paths from the workspace root in all pickers.

This change was requested to provide a consistent and complete relative path view across all Telescope pickers (e.g., `find_files`, `live_grep`), as the default "smart" path display was not desired.

---
<a href="https://cursor.com/background-agent?bcId=bc-0e236902-de06-473e-9376-5d50e0a040d7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0e236902-de06-473e-9376-5d50e0a040d7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>