### PR TITLE
Configure ruff and coc-pyright for development

### DIFF
--- a/coc-settings.json
+++ b/coc-settings.json
@@ -1,0 +1,64 @@
+{
+  "python.defaultInterpreterPath": "python3",
+  "python.formatting.provider": "none",
+  "python.linting.enabled": false,
+  "python.linting.pylintEnabled": false,
+  "python.linting.flake8Enabled": false,
+  "python.linting.pycodestyleEnabled": false,
+  "python.linting.mypyEnabled": false,
+  
+  "pyright.enable": true,
+  "pyright.completion.enabled": true,
+  "pyright.hover.enabled": true,
+  "pyright.signature.enabled": true,
+  "pyright.rename.enabled": true,
+  "pyright.references.enabled": true,
+  "pyright.definition.enabled": true,
+  "pyright.typeDefinition.enabled": true,
+  "pyright.implementation.enabled": true,
+  "pyright.codeAction.enabled": true,
+  "pyright.diagnostics.enabled": true,
+  
+  "diagnostic-languageserver.enable": true,
+  "diagnostic-languageserver.filetypes": {
+    "python": "ruff-lsp"
+  },
+  "diagnostic-languageserver.linters": {
+    "ruff-lsp": {
+      "command": "ruff",
+      "debounce": 100,
+      "args": ["check", "--output-format=json", "--stdin-filename", "%filepath", "-"],
+      "offsetLine": 0,
+      "offsetColumn": 0,
+      "sourceName": "ruff",
+      "formatLines": 1,
+      "formatPattern": [
+        "^\\[(.*)\\]$",
+        {
+          "line": -1,
+          "column": -1,
+          "message": 1
+        }
+      ]
+    }
+  },
+  "diagnostic-languageserver.formatters": {
+    "ruff-format": {
+      "command": "ruff",
+      "args": ["format", "--stdin-filename", "%filepath", "-"]
+    }
+  },
+  "diagnostic-languageserver.formatFiletypes": {
+    "python": "ruff-format"
+  },
+  
+  "languageserver": {
+    "ruff-lsp": {
+      "command": "ruff-lsp",
+      "filetypes": ["python"]
+    }
+  },
+  
+  "coc.preferences.formatOnSaveFiletypes": ["python"],
+  "coc.preferences.extensionUpdateCheck": "weekly"
+}

--- a/ftplugin/python.lua
+++ b/ftplugin/python.lua
@@ -1,1 +1,28 @@
 vim.opt.foldmethod = "indent"
+
+-- Configure ruff for formatting
+vim.opt_local.formatprg = "ruff format -"
+
+-- Set up keymaps for Python-specific actions
+local opts = { noremap = true, silent = true, buffer = true }
+
+-- Format current buffer with ruff
+vim.keymap.set("n", "<leader>rf", function()
+    vim.cmd("silent! %!ruff format -")
+end, vim.tbl_extend("force", opts, { desc = "Format with ruff" }))
+
+-- Run ruff check on current file
+vim.keymap.set("n", "<leader>rc", function()
+    vim.cmd("!ruff check " .. vim.fn.expand("%"))
+end, vim.tbl_extend("force", opts, { desc = "Check with ruff" }))
+
+-- Auto-format on save (optional, can be disabled if not desired)
+vim.api.nvim_create_autocmd("BufWritePre", {
+    buffer = 0,
+    callback = function()
+        if vim.g.ruff_format_on_save ~= false then
+            vim.lsp.buf.format({ async = false })
+        end
+    end,
+    desc = "Format Python file with ruff on save"
+})

--- a/lua/user/coc.lua
+++ b/lua/user/coc.lua
@@ -209,7 +209,8 @@ local coc_extensions = {
     'coc-pyright', 
     'coc-rust-analyzer',
     'coc-lua',
-    'coc-snippets'
+    'coc-snippets',
+    'coc-diagnostic'
 }
 
 -- Defer extension installation to avoid blocking startup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,75 @@
+[tool.ruff]
+# Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
+select = ["E", "F", "W", "I", "N", "UP", "YTT", "S", "BLE", "FBT", "B", "A", "COM", "C4", "DTZ", "T10", "DJ", "EM", "EXE", "ISC", "ICN", "G", "INP", "PIE", "T20", "PYI", "PT", "Q", "RSE", "RET", "SLF", "SIM", "TID", "TCH", "ARG", "PTH", "ERA", "PD", "PGH", "PL", "TRY", "NPY", "RUF"]
+
+# Never enforce `E501` (line length violations).
+ignore = ["E501", "COM812", "ISC001"]
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "venv",
+]
+
+# Same as Black.
+line-length = 88
+indent-width = 4
+
+# Assume Python 3.8+
+target-version = "py38"
+
+[tool.ruff.lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+select = ["E4", "E7", "E9", "F"]
+ignore = []
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
+
+# Enable auto-formatting of code examples in docstrings. Markdown,
+# reStructuredText code/literal blocks and doctests are all supported.
+docstring-code-format = false
+
+# Set the line length limit used when formatting code snippets in
+# docstrings.
+docstring-code-line-length = "dynamic"


### PR DESCRIPTION
Configure Neovim to use Ruff for Python formatting and linting, while retaining coc-pyright for other language server features.

---
<a href="https://cursor.com/background-agent?bcId=bc-655011f9-4aaa-4742-ae51-da73aa17f0b3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-655011f9-4aaa-4742-ae51-da73aa17f0b3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>