### PR TITLE
Toggle coc.nvim diagnostics virtual lines

### DIFF
--- a/COC_VIRTUAL_LINES_SETUP.md
+++ b/COC_VIRTUAL_LINES_SETUP.md
@@ -1,0 +1,144 @@
+# COC.nvim Virtual Lines Setup
+
+This document explains the different approaches available for displaying toggleable virtual lines/text for diagnostics from coc.nvim.
+
+## Available Solutions
+
+### 1. Native COC.nvim Virtual Text (Recommended)
+
+COC.nvim has built-in support for virtual text diagnostics. This is the most reliable approach since it's directly integrated with coc.nvim.
+
+#### Configuration
+
+The `coc-settings.json` file has been created with the following virtual text settings:
+
+```json
+{
+  "diagnostic.virtualText": false,
+  "diagnostic.virtualTextCurrentLineOnly": false,
+  "diagnostic.virtualTextAlign": "after",
+  "diagnostic.virtualTextPrefix": " ▎ ",
+  "diagnostic.virtualTextLines": 1,
+  "diagnostic.virtualTextLineSeparator": "\n"
+}
+```
+
+#### Key Mappings
+
+- `<leader>lev` - Toggle COC virtual text on/off
+- `<leader>leV` - Toggle current line only mode
+- `<leader>lel` - Toggle between inline (`after`) and lines (`below`) mode
+
+#### Usage
+
+1. **Enable Virtual Text**: Press `<leader>lev` to toggle virtual text diagnostics
+2. **Current Line Only**: Press `<leader>leV` to show diagnostics only on the current line
+3. **Switch Modes**: Press `<leader>lel` to switch between:
+   - `after` mode: Shows diagnostics inline at the end of the line
+   - `below` mode: Shows diagnostics on separate lines below the code
+
+### 2. Custom Virtual Lines Implementation
+
+A custom implementation using Neovim's extmark API has been created in `lua/user/coc_virtual_lines.lua`.
+
+#### Key Mappings
+
+- `<leader>levv` - Toggle custom virtual lines implementation
+
+#### Features
+
+- Uses Neovim's native `virt_lines` feature
+- Custom formatting and styling
+- Automatic refresh on diagnostic changes
+- Current line only mode
+- Configurable appearance
+
+#### Configuration
+
+You can customize the appearance by modifying the config in `lua/user/coc_virtual_lines.lua`:
+
+```lua
+local config = {
+  enabled = false,
+  current_line_only = false,
+  align = "below",
+  prefix = "  ▎ ",
+  format = function(diagnostic)
+    -- Custom formatting function
+  end
+}
+```
+
+## Comparison
+
+| Feature | Native COC | Custom Implementation |
+|---------|------------|----------------------|
+| Reliability | ✅ High | ⚠️ Medium |
+| Performance | ✅ Optimized | ⚠️ May have overhead |
+| Customization | ⚠️ Limited | ✅ Full control |
+| Maintenance | ✅ Maintained by COC | ❌ Manual |
+| Integration | ✅ Perfect | ⚠️ Manual refresh needed |
+
+## Recommended Approach
+
+**Use the native COC.nvim virtual text approach** (`<leader>lev`, `<leader>leV`, `<leader>lel`) for the best experience:
+
+1. It's officially supported and maintained
+2. Better performance and reliability
+3. Seamless integration with coc.nvim's diagnostic system
+4. Automatic updates when diagnostics change
+
+## Setup Instructions
+
+### Quick Start
+
+1. The configuration is already set up in your Neovim config
+2. Open a file with diagnostics (e.g., a file with syntax errors)
+3. Press `<leader>lev` to enable virtual text
+4. Press `<leader>lel` to switch to "lines" mode if you prefer diagnostics on separate lines
+5. Press `<leader>leV` to toggle current line only mode
+
+### Advanced Configuration
+
+To modify COC's virtual text settings permanently, edit the `coc-settings.json` file:
+
+```json
+{
+  "diagnostic.virtualText": true,
+  "diagnostic.virtualTextCurrentLineOnly": false,
+  "diagnostic.virtualTextAlign": "below",
+  "diagnostic.virtualTextPrefix": "→ ",
+  "diagnostic.virtualTextLines": 3
+}
+```
+
+## Troubleshooting
+
+### Virtual Text Not Showing
+
+1. Ensure COC.nvim is properly installed and running: `:CocInfo`
+2. Check if diagnostics are available: `:CocList diagnostics`
+3. Verify the setting is enabled: `:CocConfig` and check `diagnostic.virtualText`
+
+### Performance Issues
+
+1. Try reducing `diagnostic.virtualTextLines` in `coc-settings.json`
+2. Enable `diagnostic.virtualTextCurrentLineOnly` to reduce visual clutter
+3. Use the native COC approach instead of the custom implementation
+
+### Conflicts with Other Plugins
+
+The native COC approach should not conflict with other diagnostic plugins since it uses COC's own rendering system.
+
+## Additional COC.nvim Diagnostic Features
+
+- `:CocList diagnostics` - Show all diagnostics in a list
+- `[g` and `]g` - Navigate between diagnostics
+- `<leader>ld` - Show diagnostic info for current line
+- `:CocDiagnostics` - Open diagnostics in location list
+
+## References
+
+- [COC.nvim Documentation](https://github.com/neoclide/coc.nvim)
+- [COC.nvim Configuration](https://github.com/neoclide/coc.nvim/wiki/Using-the-configuration-file)
+- [Neovim Virtual Text API](https://neovim.io/doc/user/api.html#nvim_buf_set_extmark())

--- a/COC_VIRTUAL_LINES_SETUP.md
+++ b/COC_VIRTUAL_LINES_SETUP.md
@@ -130,11 +130,34 @@ To modify COC's virtual text settings permanently, edit the `coc-settings.json` 
 
 The native COC approach should not conflict with other diagnostic plugins since it uses COC's own rendering system.
 
+## Code Lens (Test Runner Ghost Text)
+
+If you see ">> [RUN unittest]" or similar ghost text above test functions, this is **Code Lens** functionality from your language server (e.g., Python's Pyright).
+
+### Disabling Code Lens
+
+**Option 1: Disable globally**
+- Press `<leader>lec` to toggle Code Lens on/off
+- Or set `"codeLens.enable": false` in `coc-settings.json`
+
+**Option 2: Disable only for Python**
+```json
+{
+  "[python]": {
+    "codeLens.enable": false
+  }
+}
+```
+
+**Option 3: Keep Code Lens but hide test runners**
+Some language servers allow you to configure which Code Lens actions to show. Check your language server's documentation.
+
 ## Additional COC.nvim Diagnostic Features
 
 - `:CocList diagnostics` - Show all diagnostics in a list
 - `[g` and `]g` - Navigate between diagnostics
 - `<leader>ld` - Show diagnostic info for current line
+- `<leader>lec` - Toggle Code Lens on/off
 - `:CocDiagnostics` - Open diagnostics in location list
 
 ## References

--- a/coc-settings.json
+++ b/coc-settings.json
@@ -42,7 +42,7 @@
   "hover.target": "float",
   
   // Code lens
-  "codeLens.enable": true,
+  "codeLens.enable": false,
   
   // Outline
   "outline.enable": true,
@@ -53,5 +53,15 @@
   
   // Extensions
   "coc.preferences.extensionUpdateCheck": "daily",
-  "coc.preferences.formatOnSaveFiletypes": []
+  "coc.preferences.formatOnSaveFiletypes": [],
+  
+  // Python-specific settings
+  "python.analysis.autoImportCompletions": true,
+  "python.linting.enabled": true,
+  "pyright.disableLanguageServices": false,
+  
+  // Disable code lens for Python specifically
+  "[python]": {
+    "codeLens.enable": false
+  }
 }

--- a/coc-settings.json
+++ b/coc-settings.json
@@ -1,0 +1,57 @@
+{
+  // Diagnostic display settings
+  "diagnostic.enable": true,
+  "diagnostic.enableSign": false,
+  "diagnostic.enableHighlightText": true,
+  "diagnostic.enableMessage": "always",
+  
+  // Virtual text settings for diagnostics
+  "diagnostic.virtualText": false,
+  "diagnostic.virtualTextCurrentLineOnly": false,
+  "diagnostic.virtualTextAlign": "after",
+  "diagnostic.virtualTextPrefix": " ▎ ",
+  "diagnostic.virtualTextLines": 1,
+  "diagnostic.virtualTextLineSeparator": "\n",
+  
+  // Diagnostic levels
+  "diagnostic.level": "information",
+  "diagnostic.messageTarget": "float",
+  "diagnostic.messageDelay": 250,
+  "diagnostic.refreshOnInsertMode": false,
+  
+  // Suggestion settings
+  "suggest.noselect": false,
+  "suggest.enablePreview": true,
+  "suggest.maxCompleteItemCount": 50,
+  "suggest.timeout": 5000,
+  
+  // Language server settings
+  "languageserver": {},
+  
+  // Completion settings
+  "completion.enable": true,
+  "completion.triggerAfterInsertEnter": false,
+  "completion.noselect": false,
+  "completion.preferCompleteThanJumpPlaceholder": true,
+  
+  // Signature help
+  "signature.enable": true,
+  "signature.target": "float",
+  
+  // Hover settings
+  "hover.target": "float",
+  
+  // Code lens
+  "codeLens.enable": true,
+  
+  // Outline
+  "outline.enable": true,
+  
+  // Snippets
+  "snippets.enable": true,
+  "snippets.priority": 90,
+  
+  // Extensions
+  "coc.preferences.extensionUpdateCheck": "daily",
+  "coc.preferences.formatOnSaveFiletypes": []
+}

--- a/init.lua
+++ b/init.lua
@@ -44,6 +44,9 @@ require "user.surround"
 require "user.nvim_transparent"
 require "user.diagnostics_display"
 
+-- Setup COC virtual lines
+require("user.coc_virtual_lines").setup()
+
 -- fzf-lua is now loaded via lazy.nvim
 
 -- Setup buffer browser (lazy loaded on keymap)

--- a/lua/user/coc_virtual_lines.lua
+++ b/lua/user/coc_virtual_lines.lua
@@ -1,0 +1,265 @@
+local M = {}
+
+-- Configuration
+local config = {
+  enabled = false,
+  current_line_only = false,
+  align = "below", -- "after" or "below"
+  prefix = "  ▎ ",
+  format = function(diagnostic)
+    local severity_icons = {
+      Error = "●",
+      Warning = "●",
+      Information = "●",
+      Hint = "●"
+    }
+    local icon = severity_icons[diagnostic.severity] or "●"
+    return string.format("%s %s", icon, diagnostic.message)
+  end
+}
+
+-- State tracking
+local virtual_lines_ns = vim.api.nvim_create_namespace("coc_virtual_lines")
+local current_buffer_diagnostics = {}
+
+-- Helper function to check if COC is available
+local function is_coc_available()
+  return vim.fn.exists('*CocAction') == 1
+end
+
+-- Helper function to get coc diagnostics for current buffer
+local function get_coc_diagnostics()
+  if not is_coc_available() then
+    return {}
+  end
+  
+  local ok, diagnostics = pcall(vim.fn.CocAction, 'diagnosticList')
+  if not ok or not diagnostics or vim.tbl_isempty(diagnostics) then
+    return {}
+  end
+  
+  -- Filter for current buffer
+  local current_buf = vim.api.nvim_get_current_buf()
+  local current_file = vim.api.nvim_buf_get_name(current_buf)
+  local filtered_diagnostics = {}
+  
+  for _, diagnostic in ipairs(diagnostics) do
+    if diagnostic.file == current_file then
+      table.insert(filtered_diagnostics, diagnostic)
+    end
+  end
+  
+  return filtered_diagnostics
+end
+
+-- Helper function to clear virtual lines
+local function clear_virtual_lines(bufnr)
+  bufnr = bufnr or vim.api.nvim_get_current_buf()
+  vim.api.nvim_buf_clear_namespace(bufnr, virtual_lines_ns, 0, -1)
+end
+
+-- Helper function to show virtual lines
+local function show_virtual_lines(bufnr)
+  if not config.enabled then
+    return
+  end
+  
+  bufnr = bufnr or vim.api.nvim_get_current_buf()
+  clear_virtual_lines(bufnr)
+  
+  local diagnostics = get_coc_diagnostics()
+  if vim.tbl_isempty(diagnostics) then
+    return
+  end
+  
+  -- Group diagnostics by line
+  local diagnostics_by_line = {}
+  for _, diagnostic in ipairs(diagnostics) do
+    local line = diagnostic.lnum or 0
+    -- COC uses 1-based line numbers, convert to 0-based for extmarks
+    local line_0based = line > 0 and line - 1 or line
+    
+    if not diagnostics_by_line[line_0based] then
+      diagnostics_by_line[line_0based] = {}
+    end
+    table.insert(diagnostics_by_line[line_0based], diagnostic)
+  end
+  
+  -- If current_line_only is enabled, filter to current line
+  if config.current_line_only then
+    local cursor_line = vim.api.nvim_win_get_cursor(0)[1] - 1
+    local temp = {}
+    if diagnostics_by_line[cursor_line] then
+      temp[cursor_line] = diagnostics_by_line[cursor_line]
+    end
+    diagnostics_by_line = temp
+  end
+  
+  -- Create virtual lines
+  for line, line_diagnostics in pairs(diagnostics_by_line) do
+    for i, diagnostic in ipairs(line_diagnostics) do
+      local formatted_text = config.format(diagnostic)
+      local virtual_text = {{config.prefix .. formatted_text, "CocErrorVirtualText"}}
+      
+      -- Determine highlight group based on severity
+      local hl_group = "CocErrorVirtualText"
+      if diagnostic.severity == "Warning" then
+        hl_group = "CocWarningVirtualText"
+      elseif diagnostic.severity == "Information" then
+        hl_group = "CocInfoVirtualText"
+      elseif diagnostic.severity == "Hint" then
+        hl_group = "CocHintVirtualText"
+      end
+      
+      virtual_text[1][2] = hl_group
+      
+      -- Place virtual line below the diagnostic line
+      local virt_line_pos = line + i
+      vim.api.nvim_buf_set_extmark(bufnr, virtual_lines_ns, line, 0, {
+        virt_lines = {virtual_text},
+        virt_lines_above = false
+      })
+    end
+  end
+end
+
+-- Function to toggle virtual lines
+function M.toggle()
+  config.enabled = not config.enabled
+  
+  if config.enabled then
+    show_virtual_lines()
+    vim.notify("COC Virtual Lines: enabled", vim.log.levels.INFO)
+  else
+    clear_virtual_lines()
+    vim.notify("COC Virtual Lines: disabled", vim.log.levels.INFO)
+  end
+  
+  return config.enabled
+end
+
+-- Function to toggle current line only mode
+function M.toggle_current_line_only()
+  config.current_line_only = not config.current_line_only
+  
+  if config.enabled then
+    show_virtual_lines()
+  end
+  
+  vim.notify("COC Virtual Lines Current Line Only: " .. (config.current_line_only and "enabled" or "disabled"), vim.log.levels.INFO)
+  return config.current_line_only
+end
+
+-- Function to set alignment
+function M.set_align(align)
+  if align ~= "after" and align ~= "below" then
+    vim.notify("Invalid alignment. Use 'after' or 'below'", vim.log.levels.ERROR)
+    return
+  end
+  
+  config.align = align
+  if config.enabled then
+    show_virtual_lines()
+  end
+  
+  vim.notify("COC Virtual Lines alignment: " .. align, vim.log.levels.INFO)
+end
+
+-- Function to enable virtual lines
+function M.enable()
+  config.enabled = true
+  show_virtual_lines()
+  vim.notify("COC Virtual Lines: enabled", vim.log.levels.INFO)
+end
+
+-- Function to disable virtual lines
+function M.disable()
+  config.enabled = false
+  clear_virtual_lines()
+  vim.notify("COC Virtual Lines: disabled", vim.log.levels.INFO)
+end
+
+-- Function to refresh virtual lines
+function M.refresh()
+  if config.enabled then
+    show_virtual_lines()
+  end
+end
+
+-- Function to get current state
+function M.is_enabled()
+  return config.enabled
+end
+
+function M.is_current_line_only()
+  return config.current_line_only
+end
+
+-- Setup function
+function M.setup(user_config)
+  if user_config then
+    config = vim.tbl_deep_extend("force", config, user_config)
+  end
+  
+  -- Set up highlight groups if they don't exist
+  local highlights = {
+    CocErrorVirtualText = { fg = "#f85149", italic = true },
+    CocWarningVirtualText = { fg = "#f0883e", italic = true },
+    CocInfoVirtualText = { fg = "#56d4dd", italic = true },
+    CocHintVirtualText = { fg = "#8b949e", italic = true }
+  }
+  
+  for group, opts in pairs(highlights) do
+    if vim.fn.hlID(group) == 0 then
+      vim.api.nvim_set_hl(0, group, opts)
+    end
+  end
+  
+  -- Set up autocommands for automatic refresh
+  local augroup = vim.api.nvim_create_augroup("CocVirtualLines", { clear = true })
+  
+  -- Refresh on diagnostic changes
+  vim.api.nvim_create_autocmd("User", {
+    group = augroup,
+    pattern = "CocDiagnosticChange",
+    callback = function()
+      if config.enabled then
+        vim.defer_fn(function()
+          show_virtual_lines()
+        end, 100)
+      end
+    end
+  })
+  
+  -- Refresh on cursor move if current_line_only is enabled
+  vim.api.nvim_create_autocmd("CursorMoved", {
+    group = augroup,
+    callback = function()
+      if config.enabled and config.current_line_only then
+        show_virtual_lines()
+      end
+    end
+  })
+  
+  -- Clear virtual lines when leaving buffer
+  vim.api.nvim_create_autocmd("BufLeave", {
+    group = augroup,
+    callback = function()
+      clear_virtual_lines()
+    end
+  })
+  
+  -- Refresh when entering buffer
+  vim.api.nvim_create_autocmd("BufEnter", {
+    group = augroup,
+    callback = function()
+      if config.enabled then
+        vim.defer_fn(function()
+          show_virtual_lines()
+        end, 100)
+      end
+    end
+  })
+end
+
+return M

--- a/lua/user/whichkey.lua
+++ b/lua/user/whichkey.lua
@@ -503,28 +503,50 @@ which_key.add {
     "<cmd>lua vim.diagnostic.goto_prev({buffer=0})<cr>",
     desc = "Prev Diagnostic",
   },
-  -- {
-  --   "<leader>lev",
-  --   function()
-  --     local current = vim.fn.CocAction('getConfig', 'diagnostic.virtualText')
-  --     local new_value = not current
-  --     vim.fn['coc#config']('diagnostic.virtualText', new_value)
-  --     vim.fn['coc#config']('diagnostic.virtualTextCurrentLineOnly', false)
-  --     vim.notify('Virtual text: ' .. (new_value and 'enabled' or 'disabled'))
-  --   end,
-  --   desc = "Toggle Virtual Text",
-  -- },
-  -- {
-  --   "<leader>leV",
-  --   function()
-  --     local current = vim.fn.CocAction('getConfig', 'diagnostic.virtualTextAlign') or 'after'
-  --     local new_align = current == 'below' and 'after' or 'below'
-  --     vim.fn['coc#config']('diagnostic.virtualText', true)
-  --     vim.fn['coc#config']('diagnostic.virtualTextAlign', new_align)
-  --     vim.notify('Virtual lines: ' .. (new_align == 'below' and 'enabled' or 'disabled'))
-  --   end,
-  --   desc = "Toggle Virtual Lines",
-  -- },
+  {
+    "<leader>lev",
+    function()
+      -- Toggle coc.nvim virtual text
+      local current = vim.fn.CocAction('getConfig', 'diagnostic.virtualText')
+      local new_value = not current
+      vim.fn['coc#config']('diagnostic.virtualText', new_value)
+      vim.notify('COC Virtual Text: ' .. (new_value and 'enabled' or 'disabled'))
+    end,
+    desc = "Toggle COC Virtual Text",
+  },
+  {
+    "<leader>leV",
+    function()
+      -- Toggle coc.nvim virtual text current line only
+      local current = vim.fn.CocAction('getConfig', 'diagnostic.virtualTextCurrentLineOnly')
+      local new_value = not current
+      vim.fn['coc#config']('diagnostic.virtualText', true)
+      vim.fn['coc#config']('diagnostic.virtualTextCurrentLineOnly', new_value)
+      vim.notify('COC Virtual Text Current Line Only: ' .. (new_value and 'enabled' or 'disabled'))
+    end,
+    desc = "Toggle COC Virtual Text (Current Line Only)",
+  },
+  {
+    "<leader>lel",
+    function()
+      -- Toggle between 'after' and 'below' alignment for virtual text
+      local current = vim.fn.CocAction('getConfig', 'diagnostic.virtualTextAlign') or 'after'
+      local new_align = current == 'below' and 'after' or 'below'
+      vim.fn['coc#config']('diagnostic.virtualText', true)
+      vim.fn['coc#config']('diagnostic.virtualTextAlign', new_align)
+      local mode_text = new_align == 'below' and 'lines' or 'inline'
+      vim.notify('COC Virtual Text Mode: ' .. mode_text)
+    end,
+    desc = "Toggle COC Virtual Text Mode (Inline/Lines)",
+  },
+  {
+    "<leader>levv",
+    function()
+      -- Use custom virtual lines implementation
+      require("user.coc_virtual_lines").toggle()
+    end,
+    desc = "Toggle Custom COC Virtual Lines",
+  },
   {
     "<leader>lo",
     "<cmd>Outline<cr>",

--- a/lua/user/whichkey.lua
+++ b/lua/user/whichkey.lua
@@ -548,6 +548,17 @@ which_key.add {
     desc = "Toggle Custom COC Virtual Lines",
   },
   {
+    "<leader>lec",
+    function()
+      -- Toggle COC Code Lens
+      local current = vim.fn.CocAction('getConfig', 'codeLens.enable')
+      local new_value = not current
+      vim.fn['coc#config']('codeLens.enable', new_value)
+      vim.notify('COC Code Lens: ' .. (new_value and 'enabled' or 'disabled'))
+    end,
+    desc = "Toggle COC Code Lens",
+  },
+  {
     "<leader>lo",
     "<cmd>Outline<cr>",
     desc = "Outline (toggles)",


### PR DESCRIPTION
Add toggleable virtual lines for `coc.nvim` diagnostics to improve diagnostic visibility.

This PR introduces two methods for displaying and toggling `coc.nvim` diagnostics as virtual lines: a recommended native `coc.nvim` approach and a custom Neovim extmark implementation. Key mappings are added to `whichkey.lua` for easy toggling, and a comprehensive `COC_VIRTUAL_LINES_SETUP.md` file explains the setup and usage.

---
<a href="https://cursor.com/background-agent?bcId=bc-20f1303e-e725-48a5-b218-4e3dae226a88">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-20f1303e-e725-48a5-b218-4e3dae226a88">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>