### PR TITLE
Fix grep display and add quickfix shortcut

### DIFF
--- a/lua/user/fzf-lua.lua
+++ b/lua/user/fzf-lua.lua
@@ -44,6 +44,7 @@ fzf_lua.setup({
             ["<F4>"] = "toggle-preview",
             ["<C-d>"] = "preview-page-down",
             ["<C-u>"] = "preview-page-up",
+            ["<C-q>"] = "select-all+accept", -- Send all results to quickfix
         },
         fzf = {
             ["ctrl-z"] = "abort",
@@ -55,12 +56,13 @@ fzf_lua.setup({
             ["alt-a"] = "toggle-all",
             ["f3"] = "toggle-preview-wrap",
             ["f4"] = "toggle-preview",
+            ["ctrl-q"] = "select-all+accept", -- Send all results to quickfix
         },
     },
     
     -- FZF options for performance
     fzf_opts = {
-        ["--ansi"] = false, -- Disable ANSI for performance
+        ["--ansi"] = true, -- Enable ANSI to properly handle colored grep output
         ["--info"] = "hidden", -- Hide info for performance
         ["--height"] = "100%",
         ["--layout"] = "reverse",
@@ -78,6 +80,11 @@ fzf_lua.setup({
                 if #selected > 0 then
                     vim.cmd("edit " .. vim.fn.fnameescape(selected[1]))
                 end
+            end,
+            ["ctrl-q"] = function(selected, opts)
+                -- Send selected files to quickfix list
+                require("fzf-lua.actions").file_sel_to_qf(selected, opts)
+                vim.cmd("copen")
             end,
         },
     },
@@ -125,6 +132,13 @@ fzf_lua.setup({
         rg_glob = true,
         glob_flag = "--iglob",
         glob_separator = "%s%-%-",
+        actions = {
+            ["ctrl-q"] = function(selected, opts)
+                -- Send grep results to quickfix list
+                require("fzf-lua.actions").grep_to_qf(selected, opts)
+                vim.cmd("copen")
+            end,
+        },
     },
     
     -- Live grep optimizations
@@ -137,6 +151,13 @@ fzf_lua.setup({
         rg_opts = "--column --line-number --no-heading --color=always --smart-case --max-columns=4096",
         -- Performance: disable some features for speed
         exec_empty_query = false,
+        actions = {
+            ["ctrl-q"] = function(selected, opts)
+                -- Send live grep results to quickfix list
+                require("fzf-lua.actions").grep_to_qf(selected, opts)
+                vim.cmd("copen")
+            end,
+        },
     },
     
     -- Buffer optimizations  
@@ -148,6 +169,13 @@ fzf_lua.setup({
         show_unloaded = true,
         cwd_only = false,
         previewer = false, -- Disable previewer for instant opening
+        actions = {
+            ["ctrl-q"] = function(selected, opts)
+                -- Send buffer list to quickfix list
+                require("fzf-lua.actions").buf_sel_to_qf(selected, opts)
+                vim.cmd("copen")
+            end,
+        },
     },
     
     -- Help tags
@@ -215,6 +243,13 @@ fzf_lua.setup({
         file_icons = true,
         git_icons = false,
         diag_icons = true,
+        actions = {
+            ["ctrl-q"] = function(selected, opts)
+                -- Send diagnostics to quickfix list
+                require("fzf-lua.actions").diag_to_qf(selected, opts)
+                vim.cmd("copen")
+            end,
+        },
     },
     
     -- Quickfix

--- a/lua/user/keymaps.lua
+++ b/lua/user/keymaps.lua
@@ -181,6 +181,11 @@ _G.find_files = function()
         path_display = { "smart" },
         previewer = false,
         follow = false,
+        attach_mappings = function(_, map)
+            map("i", "<C-q>", require("telescope.actions").send_to_qflist + require("telescope.actions").open_qflist)
+            map("n", "<C-q>", require("telescope.actions").send_to_qflist + require("telescope.actions").open_qflist)
+            return true
+        end,
     }
 end
 _G.live_grep = function()
@@ -193,6 +198,11 @@ _G.live_grep = function()
         results_limit = 100,
         path_display = { "smart" },
         previewer = false,
+        attach_mappings = function(_, map)
+            map("i", "<C-q>", require("telescope.actions").send_to_qflist + require("telescope.actions").open_qflist)
+            map("n", "<C-q>", require("telescope.actions").send_to_qflist + require("telescope.actions").open_qflist)
+            return true
+        end,
     }
 end
 
@@ -250,12 +260,22 @@ vim.keymap.set('n', '<leader>fb', function()
   require('telescope.builtin').find_files {
     search_dirs = { '/prod/tools/base/' },
     theme = 'ivy',
+    attach_mappings = function(_, map)
+      map("i", "<C-q>", require("telescope.actions").send_to_qflist + require("telescope.actions").open_qflist)
+      map("n", "<C-q>", require("telescope.actions").send_to_qflist + require("telescope.actions").open_qflist)
+      return true
+    end,
   }
 end, { desc = 'Find files in base' })
 vim.keymap.set('n', '<leader>gb', function()
   require('telescope.builtin').live_grep {
     search_dirs = { '/prod/tools/base/' },
     theme = 'ivy',
+    attach_mappings = function(_, map)
+      map("i", "<C-q>", require("telescope.actions").send_to_qflist + require("telescope.actions").open_qflist)
+      map("n", "<C-q>", require("telescope.actions").send_to_qflist + require("telescope.actions").open_qflist)
+      return true
+    end,
   }
 end, { desc = 'Live grep in base' })
 


### PR DESCRIPTION
Fix grep display issues and add Ctrl+Q to send picker results to the quickfix list.

---
<a href="https://cursor.com/background-agent?bcId=bc-d1551acf-2b4a-47ec-bab5-f5ce59b156fe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d1551acf-2b4a-47ec-bab5-f5ce59b156fe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>