### PR TITLE
Remove FTerm and add centered floating terminal

### DIFF
--- a/lua/user/lualine.lua
+++ b/lua/user/lualine.lua
@@ -72,16 +72,6 @@ local filetype = {
             "Outline",
             "spectre_panel",
             "terminal",
-            "fterm_float",
-            "fterm_vertical", 
-            "fterm_horizontal",
-            "fterm_lazygit",
-            "fterm_node",
-            "fterm_ncdu",
-            "fterm_htop",
-            "fterm_make",
-            "fterm_cargo_run",
-            "fterm_cargo_test",
             "DressingSelect",
             "",
             "nil",
@@ -104,7 +94,7 @@ local filetype = {
             return toggle_num
         end
 
-        if str == "terminal" or str:match("^fterm_") then
+        if str == "terminal" then
             -- 
             local term = " " .. "%*" .. "TERM" .. "%*"
 
@@ -190,16 +180,6 @@ local spaces = {
             "Outline",
             "spectre_panel",
             "terminal",
-            "fterm_float",
-            "fterm_vertical", 
-            "fterm_horizontal",
-            "fterm_lazygit",
-            "fterm_node",
-            "fterm_ncdu",
-            "fterm_htop",
-            "fterm_make",
-            "fterm_cargo_run",
-            "fterm_cargo_test",
             "DressingSelect",
             "",
         }
@@ -236,16 +216,6 @@ local lanuage_server = {
             "Outline",
             "spectre_panel",
             "terminal",
-            "fterm_float",
-            "fterm_vertical", 
-            "fterm_horizontal",
-            "fterm_lazygit",
-            "fterm_node",
-            "fterm_ncdu",
-            "fterm_htop",
-            "fterm_make",
-            "fterm_cargo_run",
-            "fterm_cargo_test",
             "DressingSelect",
             "TelescopePrompt",
             "lspinfo",

--- a/lua/user/whichkey.lua
+++ b/lua/user/whichkey.lua
@@ -673,8 +673,8 @@ which_key.add {
   },
   {
     "<leader>T4",
-    "<cmd>lua require('FTerm').toggle()<cr>",
-    desc = "Default Terminal",
+    "<cmd>lua _FLOAT_TERM()<cr>",
+    desc = "Float Terminal",
   },
   {
     "<leader>Tn",


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Replaced FTerm with a native floating terminal implementation and added a `Ctrl+\` keybinding for a centered terminal.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This change removes all FTerm dependencies, cleans up related configurations in `lualine.lua` and `whichkey.lua`, and introduces a new, custom-sized (60% screen) floating terminal accessible via `Ctrl+\`.

---
<a href="https://cursor.com/background-agent?bcId=bc-81ebeb18-fe22-4a5b-a890-37b42287b850">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-81ebeb18-fe22-4a5b-a890-37b42287b850">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>