### PR TITLE
Add markdown preview split plugin

### DIFF
--- a/lua/user/markdown_preview.lua
+++ b/lua/user/markdown_preview.lua
@@ -1,0 +1,72 @@
+local M = {}
+
+function M.setup()
+    require("glow").setup({
+        glow_path = "", -- will use glow from PATH
+        install_path = "~/.local/bin", -- fallback installation path
+        border = "shadow", -- floating window border
+        style = "dark", -- filled automatically with your current editor background
+        pager = false,
+        width = 120,
+        height = 100,
+        width_ratio = 0.8, -- maximum width of the Glow window compared to the nvim window size (overrides `width`)
+        height_ratio = 0.8,
+    })
+end
+
+-- Function to open markdown preview in vertical split
+function M.preview_vertical_split()
+    -- Save current window
+    local current_win = vim.api.nvim_get_current_win()
+    
+    -- Create vertical split
+    vim.cmd("vsplit")
+    
+    -- Run Glow in the new split
+    vim.cmd("Glow")
+    
+    -- Go back to original window
+    vim.api.nvim_set_current_win(current_win)
+end
+
+-- Function to toggle markdown preview
+function M.toggle_preview()
+    -- Check if there's already a Glow buffer open
+    local glow_buf = nil
+    for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+        local buf_name = vim.api.nvim_buf_get_name(buf)
+        if buf_name:match("glow://") then
+            glow_buf = buf
+            break
+        end
+    end
+    
+    if glow_buf then
+        -- Close the glow buffer
+        vim.api.nvim_buf_delete(glow_buf, { force = true })
+    else
+        -- Open glow preview
+        M.preview_vertical_split()
+    end
+end
+
+-- Set up keymaps for markdown files
+function M.setup_keymaps()
+    vim.api.nvim_create_autocmd("FileType", {
+        pattern = "markdown",
+        callback = function()
+            local opts = { desc = "Markdown Preview", buffer = true, silent = true }
+            
+            -- Basic preview (floating window)
+            vim.keymap.set("n", "<leader>mp", "<cmd>Glow<cr>", vim.tbl_extend("force", opts, { desc = "Markdown Preview (Float)" }))
+            
+            -- Preview in vertical split
+            vim.keymap.set("n", "<leader>mv", function() M.preview_vertical_split() end, vim.tbl_extend("force", opts, { desc = "Markdown Preview (Vertical Split)" }))
+            
+            -- Toggle preview
+            vim.keymap.set("n", "<leader>mt", function() M.toggle_preview() end, vim.tbl_extend("force", opts, { desc = "Toggle Markdown Preview" }))
+        end,
+    })
+end
+
+return M

--- a/lua/user/plugins.lua
+++ b/lua/user/plugins.lua
@@ -598,15 +598,20 @@ require("lazy").setup {
                     },
                 },
             },
-            {
-                -- Make sure to set this up properly if you have lazy=true
-                'MeanderingProgrammer/render-markdown.nvim',
-                opts = {
-                    file_types = { "markdown", "Avante" },
-                },
-                ft = { "markdown", "Avante" },
-            },
+            -- Removed render-markdown.nvim to avoid weird buffer rendering
         },
+    },
+
+    -- Markdown Preview - LAZY LOAD
+    {
+        "ellisonleao/glow.nvim",
+        ft = "markdown",
+        cmd = "Glow",
+        config = function()
+            local markdown_preview = require("user.markdown_preview")
+            markdown_preview.setup()
+            markdown_preview.setup_keymaps()
+        end,
     },
 
     -- LSP Saga - LAZY LOAD


### PR DESCRIPTION
Replace `render-markdown.nvim` with `glow.nvim` to provide markdown preview in a separate vertical split instead of in-buffer rendering.

The previous `render-markdown.nvim` plugin rendered markdown directly within the Neovim buffer, which was not the desired behavior. This change implements `glow.nvim` to offer a dedicated, separate preview in a vertical split or floating window, keeping the original markdown buffer clean.

---
<a href="https://cursor.com/background-agent?bcId=bc-dbf2869a-9e9e-4919-b803-d5d33ad4eefb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dbf2869a-9e9e-4919-b803-d5d33ad4eefb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>