### PR TITLE
Fix lazygit not found error for gg command

### DIFF
--- a/LAZYGIT_TERMINAL_FIXES.md
+++ b/LAZYGIT_TERMINAL_FIXES.md
@@ -1,0 +1,49 @@
+# Lazygit Terminal Integration Fixes
+
+## Issues Fixed
+
+### 1. Lag with Navigation Keys (j, k, etc.)
+**Problem**: Pressing navigation keys in lazygit UI had noticeable lag.
+
+**Root Cause**: The global `TermOpen` autocmd was applying generic terminal keymaps to all terminal buffers, including lazygit. This created keymap conflicts and timeout issues.
+
+**Solution**: 
+- Set lazygit buffers to have `filetype = "lazygit"` before opening the terminal
+- Modified the global `TermOpen` autocmd to skip lazygit buffers
+- Created specialized keymaps only for lazygit that don't conflict with its internal navigation
+
+### 2. Escape Key Behavior
+**Problem**: Pressing `<Esc>` in lazygit would exit terminal mode and enter Neovim normal mode instead of working within lazygit's UI as expected.
+
+**Root Cause**: The global terminal keymaps were binding `<Esc>` to `<C-\><C-n>` which exits terminal mode.
+
+**Solution**:
+- Lazygit buffers now only bind `<C-\><C-n>` for exiting terminal mode
+- `<Esc>` key is left unmapped so it passes through to lazygit
+- This allows lazygit to handle `<Esc>` according to its own UI logic
+
+## Technical Changes
+
+### Modified Functions
+- `M.lazygit_float()`: Now sets filetype and uses minimal keymaps
+- `M.lazygit_tab()`: Now sets filetype and uses minimal keymaps
+- Global `TermOpen` autocmd: Now skips lazygit buffers
+
+### Keymaps for Lazygit
+- `<C-\><C-n>`: Exit terminal mode (only way to get to normal mode)
+- `<C-h/j/k/l>`: Window navigation from terminal mode
+- `q`: Close lazygit window (from normal mode)
+- `<Esc>`: **Unmapped** - passes through to lazygit
+
+### Keymaps for Regular Terminals
+- `<Esc>`: Exit terminal mode
+- `<C-h/j/k/l>`: Window navigation
+- `q`: Close terminal (from normal mode)
+
+## Usage
+
+Both lazygit modes should now work smoothly:
+- `<leader>gg`: Floating lazygit window
+- `<leader>gG`: Lazygit in new tab
+
+Navigation within lazygit should be responsive, and `<Esc>` should work as expected within the lazygit interface.

--- a/LAZYGIT_TERMINAL_FIXES.md
+++ b/LAZYGIT_TERMINAL_FIXES.md
@@ -25,15 +25,20 @@
 ## Technical Changes
 
 ### Modified Functions
-- `M.lazygit_float()`: Now sets filetype and uses minimal keymaps
-- `M.lazygit_tab()`: Now sets filetype and uses minimal keymaps
+- `M.lazygit_float()`: Optimized window creation, minimal keymaps, no unnecessary navigation bindings
+- `M.lazygit_tab()`: Simplified implementation with minimal overhead
 - Global `TermOpen` autocmd: Now skips lazygit buffers
 
+### Performance Optimizations
+- **Removed excessive keymaps**: Eliminated window navigation keymaps (`<C-h/j/k/l>`) that were causing conflicts
+- **Streamlined buffer creation**: Set buffer properties before window creation
+- **Inline window creation**: Avoided helper function overhead for floating windows
+- **Minimal keymap set**: Only essential keymaps to reduce processing overhead
+
 ### Keymaps for Lazygit
-- `<C-\><C-n>`: Exit terminal mode (only way to get to normal mode)
-- `<C-h/j/k/l>`: Window navigation from terminal mode
-- `q`: Close lazygit window (from normal mode)
+- `q`: Close lazygit window (from normal mode, floating window only)
 - `<Esc>`: **Unmapped** - passes through to lazygit
+- **No terminal mode keymaps**: All navigation handled by lazygit itself
 
 ### Keymaps for Regular Terminals
 - `<Esc>`: Exit terminal mode

--- a/lua/user/keymaps.lua
+++ b/lua/user/keymaps.lua
@@ -286,7 +286,7 @@ keymap("n", "<leader>dd", "<cmd>lua require('user.diagnostics_display').debug()<
 keymap("n", "<leader>dt", "<cmd>lua require('user.diagnostics_display').test_line_numbers()<cr>", opts)
 
 -- Lazygit keymaps
-keymap("n", "<leader>gg", "<cmd>lua require('user.lazygit').lazygit_toggle_float()<cr>", opts)
-keymap("n", "<leader>gt", "<cmd>lua require('user.lazygit').lazygit_toggle_tab()<cr>", opts)
+keymap("n", "<leader>gg", "<cmd>lua require('user.terminal').lazygit_float()<cr>", opts)
+keymap("n", "<leader>gt", "<cmd>lua require('user.terminal').lazygit_tab()<cr>", opts)
 
 return M

--- a/lua/user/terminal.lua
+++ b/lua/user/terminal.lua
@@ -292,6 +292,9 @@ function M.lazygit_float()
     once = true,
   })
   
+  -- Start in insert mode for immediate lazygit interaction
+  vim.cmd("startinsert")
+  
   return buf, win, job_id
 end
 

--- a/lua/user/terminal.lua
+++ b/lua/user/terminal.lua
@@ -249,33 +249,37 @@ end
 
 -- Lazygit integration
 function M.lazygit_float()
-  local buf, win = create_float_window(0.95, 0.95, "Lazygit")
-  
-  vim.api.nvim_set_current_buf(buf)
-  
-  -- Set buffer options before opening terminal to prevent autocmd interference
+  -- Create buffer first and set its properties
+  local buf = vim.api.nvim_create_buf(false, true)
   vim.api.nvim_buf_set_option(buf, "filetype", "lazygit")
   
+  -- Create floating window
+  local width = math.floor(vim.o.columns * 0.95)
+  local height = math.floor(vim.o.lines * 0.95)
+  local col = math.floor((vim.o.columns - width) / 2)
+  local row = math.floor((vim.o.lines - height) / 2)
+  
+  local win = vim.api.nvim_open_win(buf, true, {
+    relative = "editor",
+    width = width,
+    height = height,
+    col = col,
+    row = row,
+    border = config.border,
+    title = "Lazygit",
+    title_pos = "center",
+    style = "minimal",
+  })
+  
+  -- Open terminal
   local job_id = vim.fn.termopen("lazygit")
   
-  -- Lazygit-specific keymaps - minimal set to avoid conflicts
-  local opts = { buffer = buf, noremap = true, silent = true }
-  
-  -- Only allow Ctrl+\ Ctrl+n to exit terminal mode (not Esc)
-  vim.keymap.set("t", "<C-\\><C-n>", [[<C-\><C-n>]], opts)
-  
-  -- Window navigation that works from terminal mode
-  vim.keymap.set("t", "<C-h>", [[<C-\><C-n><C-w>h]], opts)
-  vim.keymap.set("t", "<C-j>", [[<C-\><C-n><C-w>j]], opts)
-  vim.keymap.set("t", "<C-k>", [[<C-\><C-n><C-w>k]], opts)
-  vim.keymap.set("t", "<C-l>", [[<C-\><C-n><C-w>l]], opts)
-  
-  -- Close window from normal mode
+  -- Minimal keymaps - only close function
   vim.keymap.set("n", "q", function()
     if vim.api.nvim_win_is_valid(win) then
       vim.api.nvim_win_close(win, true)
     end
-  end, opts)
+  end, { buffer = buf, noremap = true, silent = true })
   
   -- Auto-close window when lazygit exits
   vim.api.nvim_create_autocmd("TermClose", {
@@ -287,9 +291,6 @@ function M.lazygit_float()
     end,
     once = true,
   })
-  
-  -- Start in insert mode
-  vim.cmd("startinsert")
   
   return buf, win, job_id
 end
@@ -305,18 +306,6 @@ function M.lazygit_tab()
   
   -- Set buffer name
   vim.api.nvim_buf_set_name(buf, "lazygit")
-  
-  -- Lazygit-specific keymaps for tab mode
-  local opts = { buffer = buf, noremap = true, silent = true }
-  
-  -- Only allow Ctrl+\ Ctrl+n to exit terminal mode (not Esc)
-  vim.keymap.set("t", "<C-\\><C-n>", [[<C-\><C-n>]], opts)
-  
-  -- Window navigation
-  vim.keymap.set("t", "<C-h>", [[<C-\><C-n><C-w>h]], opts)
-  vim.keymap.set("t", "<C-j>", [[<C-\><C-n><C-w>j]], opts)
-  vim.keymap.set("t", "<C-k>", [[<C-\><C-n><C-w>k]], opts)
-  vim.keymap.set("t", "<C-l>", [[<C-\><C-n><C-w>l]], opts)
   
   -- Start in insert mode
   vim.cmd("startinsert")

--- a/lua/user/terminal.lua
+++ b/lua/user/terminal.lua
@@ -382,7 +382,6 @@ local function setup_keymaps()
   vim.keymap.set("t", "<C-\\>", M.toggle_centered_terminal, opts)
   
   -- Lazygit
-  vim.keymap.set("n", "<leader>gg", M.lazygit_float, { desc = "Lazygit Float", noremap = true, silent = true })
   vim.keymap.set("n", "<leader>gG", M.lazygit_tab, { desc = "Lazygit Tab", noremap = true, silent = true })
 end
 

--- a/lua/user/whichkey.lua
+++ b/lua/user/whichkey.lua
@@ -363,12 +363,12 @@ which_key.add {
   -- Git
   {
     "<leader>gg",
-    "<cmd>lua require('user.lazygit').lazygit_toggle_float()<cr>",
+    "<cmd>lua require('user.terminal').lazygit_float()<cr>",
     desc = "Lazygit (Float)",
   },
   {
     "<leader>gt",
-    "<cmd>lua require('user.lazygit').lazygit_toggle_tab()<cr>",
+    "<cmd>lua require('user.terminal').lazygit_tab()<cr>",
     desc = "Lazygit (Tab)",
   },
   {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes `<leader>gg` keybinding for Lazygit by correcting module references and removing a redundant keymap.

---
<a href="https://cursor.com/background-agent?bcId=bc-174c4d84-a8bf-4dac-8744-01c0505cf903">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-174c4d84-a8bf-4dac-8744-01c0505cf903">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>