### PR TITLE
Fix empty buffer on search result

### DIFF
--- a/lua/user/fzf-lua.lua
+++ b/lua/user/fzf-lua.lua
@@ -137,6 +137,35 @@ fzf_lua.setup({
         glob_flag = "--iglob",
         glob_separator = "%s%-%-",
         actions = {
+            ["enter"] = function(selected, opts)
+                -- Parse the grep result and open the file at the correct line and column
+                if #selected > 0 then
+                    local line = selected[1]
+                    -- Strip ANSI color codes first
+                    local clean_line = line:gsub("\27%[[0-9;]*m", "")
+                    
+                    -- Parse grep result format: filename:line:col:text
+                    local filename, lnum, col, text = clean_line:match("([^:]+):(%d+):(%d+):(.*)")
+                    if filename and lnum and col then
+                        -- Open the file and jump to the line and column
+                        vim.cmd("edit " .. vim.fn.fnameescape(filename))
+                        vim.api.nvim_win_set_cursor(0, {tonumber(lnum), tonumber(col) - 1})
+                    else
+                        -- Fallback: try to parse as just filename:line
+                        local fname, line_num = clean_line:match("([^:]+):(%d+):")
+                        if fname and line_num then
+                            vim.cmd("edit " .. vim.fn.fnameescape(fname))
+                            vim.api.nvim_win_set_cursor(0, {tonumber(line_num), 0})
+                        else
+                            -- Last fallback: treat as filename only
+                            local file_path = clean_line:match("^%s*(.-)%s*$") -- trim whitespace
+                            if file_path and file_path ~= "" then
+                                vim.cmd("edit " .. vim.fn.fnameescape(file_path))
+                            end
+                        end
+                    end
+                end
+            end,
             ["ctrl-q"] = function(selected, opts)
                 _G.fzf_send_to_qf_all(selected, opts)
             end,
@@ -158,6 +187,35 @@ fzf_lua.setup({
         end,
         exec_empty_query = false,
         actions = {
+            ["enter"] = function(selected, opts)
+                -- Parse the grep result and open the file at the correct line and column
+                if #selected > 0 then
+                    local line = selected[1]
+                    -- Strip ANSI color codes first
+                    local clean_line = line:gsub("\27%[[0-9;]*m", "")
+                    
+                    -- Parse grep result format: filename:line:col:text
+                    local filename, lnum, col, text = clean_line:match("([^:]+):(%d+):(%d+):(.*)")
+                    if filename and lnum and col then
+                        -- Open the file and jump to the line and column
+                        vim.cmd("edit " .. vim.fn.fnameescape(filename))
+                        vim.api.nvim_win_set_cursor(0, {tonumber(lnum), tonumber(col) - 1})
+                    else
+                        -- Fallback: try to parse as just filename:line
+                        local fname, line_num = clean_line:match("([^:]+):(%d+):")
+                        if fname and line_num then
+                            vim.cmd("edit " .. vim.fn.fnameescape(fname))
+                            vim.api.nvim_win_set_cursor(0, {tonumber(line_num), 0})
+                        else
+                            -- Last fallback: treat as filename only
+                            local file_path = clean_line:match("^%s*(.-)%s*$") -- trim whitespace
+                            if file_path and file_path ~= "" then
+                                vim.cmd("edit " .. vim.fn.fnameescape(file_path))
+                            end
+                        end
+                    end
+                end
+            end,
             ["ctrl-q"] = function(selected, opts)
                 _G.fzf_send_to_qf_all(selected, opts)
             end,


### PR DESCRIPTION
Add custom 'enter' actions to FzfLua `live_grep` and `grep` to correctly open files from search results.

---
<a href="https://cursor.com/background-agent?bcId=bc-6a2ebe36-e403-46db-9d28-894239234dcd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6a2ebe36-e403-46db-9d28-894239234dcd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>