### PR TITLE
Fix treesitter highlighter invalid end_row error

### DIFF
--- a/lua/user/options.lua
+++ b/lua/user/options.lua
@@ -69,6 +69,20 @@ vim.cmd [[let g:python_recommended_style = 0]]
 vim.opt.foldmethod = "expr"
 vim.wo.foldexpr = "nvim_treesitter#foldexpr()"
 
+-- Disable treesitter folding for terminal buffers to prevent highlighter errors
+vim.api.nvim_create_autocmd("TermOpen", {
+  pattern = "*",
+  callback = function()
+    local buf = vim.api.nvim_get_current_buf()
+    -- Set buffer-local options to prevent treesitter issues
+    vim.api.nvim_buf_set_option(buf, "filetype", "")
+    vim.wo.foldmethod = "manual"
+    vim.wo.foldexpr = ""
+    -- Disable syntax highlighting completely for terminal buffers
+    vim.cmd("setlocal syntax=off")
+  end,
+})
+
 vim.api.nvim_set_hl(0, "NormalFloat", { bg = "#1e222a" })
 vim.opt.whichwrap:append "<>[]hl"
 

--- a/lua/user/terminal.lua
+++ b/lua/user/terminal.lua
@@ -51,6 +51,12 @@ local function create_split_terminal(direction, size_ratio, cmd)
   end
   
   local buf = vim.api.nvim_get_current_buf()
+  
+  -- Preemptively disable treesitter and syntax highlighting to prevent errors
+  vim.api.nvim_buf_set_option(buf, "syntax", "off")
+  vim.wo.foldmethod = "manual"
+  vim.wo.foldexpr = ""
+  
   local job_id = vim.fn.termopen(cmd or config.shell)
   
   return buf, job_id
@@ -79,6 +85,9 @@ vim.api.nvim_create_autocmd("TermOpen", {
   callback = function()
     local buf = vim.api.nvim_get_current_buf()
     local filetype = vim.api.nvim_buf_get_option(buf, "filetype")
+    
+    -- Disable treesitter highlighting for all terminal buffers to prevent errors
+    vim.api.nvim_buf_set_option(buf, "syntax", "off")
     
     -- Skip lazygit buffers - they have their own keymaps
     if filetype ~= "lazygit" then

--- a/lua/user/treesitter.lua
+++ b/lua/user/treesitter.lua
@@ -13,8 +13,14 @@ configs.setup {
   highlight = {
     enable = true, -- false will disable the whole extension
     disable = { "markdown", "css", "html" }, -- Disable for heavy file types
-    -- Disable for large files
+    -- Disable for large files and terminal buffers
     disable = function(lang, buf)
+      -- Disable for terminal buffers to prevent highlighter errors
+      local buftype = vim.api.nvim_buf_get_option(buf, "buftype")
+      if buftype == "terminal" then
+        return true
+      end
+      
       local max_filesize = 50 * 1024 -- Reduced from 100 KB for better performance
       local ok, stats = pcall(vim.loop.fs_stat, vim.api.nvim_buf_get_name(buf))
       if ok and stats and stats.size > max_filesize then


### PR DESCRIPTION
Fix treesitter highlighter error in horizontal terminals by excluding terminal buffers from treesitter processing.

The error "Invalid 'end_row': out of range" occurred because Neovim's treesitter was attempting to apply syntax highlighting and folding to terminal buffers, which do not contain parsable code. This PR introduces multiple safeguards at the treesitter configuration, autocmd, and buffer creation levels to prevent treesitter from processing terminal content, thus resolving the error.

---
<a href="https://cursor.com/background-agent?bcId=bc-b512392b-4324-41b9-a585-c5be2ada563b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b512392b-4324-41b9-a585-c5be2ada563b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>