### PR TITLE
Replace telescope with fzf-lua keymaps

### DIFF
--- a/lua/user/keymaps.lua
+++ b/lua/user/keymaps.lua
@@ -174,35 +174,22 @@ _G.find_files = function()
     local current_path = vim.fn.expand "%:p:h"
     local relative_path = vim.fn.fnamemodify(current_path, ":~:.")
 
-    require("telescope.builtin").find_files {
-        search_dirs = { relative_path },
-        debounce = 50,
-        results_limit = 100,
-        path_display = { "smart" },
-        previewer = false,
-        follow = false,
-        attach_mappings = function(_, map)
-            map("i", "<C-q>", require("telescope.actions").send_to_qflist + require("telescope.actions").open_qflist)
-            map("n", "<C-q>", require("telescope.actions").send_to_qflist + require("telescope.actions").open_qflist)
-            return true
-        end,
+    require("fzf-lua").files {
+        cwd = relative_path,
+        winopts = {
+            preview = { hidden = true },
+        },
     }
 end
 _G.live_grep = function()
     local current_path = vim.fn.expand "%:p:h"
     local relative_path = vim.fn.fnamemodify(current_path, ":~:.")
 
-    require("telescope.builtin").live_grep {
-        search_dirs = { relative_path },
-        debounce = 50,
-        results_limit = 100,
-        path_display = { "smart" },
-        previewer = false,
-        attach_mappings = function(_, map)
-            map("i", "<C-q>", require("telescope.actions").send_to_qflist + require("telescope.actions").open_qflist)
-            map("n", "<C-q>", require("telescope.actions").send_to_qflist + require("telescope.actions").open_qflist)
-            return true
-        end,
+    require("fzf-lua").live_grep {
+        cwd = relative_path,
+        winopts = {
+            preview = { hidden = true },
+        },
     }
 end
 
@@ -215,7 +202,7 @@ vim.api.nvim_set_keymap("n", "<Leader><leader>g", ":lua live_grep()<CR>", { nore
 -- vim.api.nvim_set_keymap("n", "<leader>zm", '[[:lua require("ufo").openAllFolds()<CR>]]', opts)
 -- vim.api.nvim_set_keymap("n", "<leader>zr", '[[:lua require("ufo").closeAllFolds()<CR>]]', opts)
 
-vim.api.nvim_set_keymap("n", "<leader><leader>s", ":silent Telescope cmdline<CR>", opts)
+vim.api.nvim_set_keymap("n", "<leader><leader>s", ":FzfLua command_history<CR>", opts)
 -- vim.keymap.set("n", "zR", require("ufo").openAllFolds)
 -- vim.keymap.set("n", "zM", require("ufo").closeAllFolds)
 -- vim.keymap.set("n", "zr", require("ufo").openFoldsExceptKinds)
@@ -254,28 +241,24 @@ vim.keymap.set(
   { desc = "Git Browse (copy)" }
 )
 
--- nnoremap <leader>fb <cmd>Telescope find_files theme=ivy search_dirs={"/prod/tools/base/"}<cr>
--- nnoremap <leader>gb <cmd>Telescope live_grep theme=ivy search_dirs={"/prod/tools/base/"}<cr>
+-- nnoremap <leader>fb <cmd>FzfLua files cwd=/prod/tools/base/<cr>
+-- nnoremap <leader>gb <cmd>FzfLua live_grep cwd=/prod/tools/base/<cr>
 vim.keymap.set('n', '<leader>fb', function()
-  require('telescope.builtin').find_files {
-    search_dirs = { '/prod/tools/base/' },
-    theme = 'ivy',
-    attach_mappings = function(_, map)
-      map("i", "<C-q>", require("telescope.actions").send_to_qflist + require("telescope.actions").open_qflist)
-      map("n", "<C-q>", require("telescope.actions").send_to_qflist + require("telescope.actions").open_qflist)
-      return true
-    end,
+  require('fzf-lua').files {
+    cwd = '/prod/tools/base/',
+    winopts = {
+      height = 0.6,
+      width = 0.8,
+    },
   }
 end, { desc = 'Find files in base' })
 vim.keymap.set('n', '<leader>gb', function()
-  require('telescope.builtin').live_grep {
-    search_dirs = { '/prod/tools/base/' },
-    theme = 'ivy',
-    attach_mappings = function(_, map)
-      map("i", "<C-q>", require("telescope.actions").send_to_qflist + require("telescope.actions").open_qflist)
-      map("n", "<C-q>", require("telescope.actions").send_to_qflist + require("telescope.actions").open_qflist)
-      return true
-    end,
+  require('fzf-lua').live_grep {
+    cwd = '/prod/tools/base/',
+    winopts = {
+      height = 0.6,
+      width = 0.8,
+    },
   }
 end, { desc = 'Live grep in base' })
 

--- a/lua/user/simple_tree.lua
+++ b/lua/user/simple_tree.lua
@@ -517,7 +517,7 @@ local function show_help()
     "  Y           - Copy absolute path",
     "",
     "Other:",
-    "  /           - Search files with Telescope",
+    "  /           - Search files with FzfLua",
     "  R           - Refresh tree",
     "  H           - Toggle hidden files",
     "  w           - Open file in GitHub",
@@ -660,24 +660,22 @@ local function handle_horizontal_split()
   end
 end
 
--- Telescope integration for search
+-- FzfLua integration for search
 local function open_telescope_in_directory()
-  local telescope_ok, telescope = pcall(require, 'telescope.builtin')
-  if not telescope_ok then
-    print("Telescope not available")
+  local fzf_ok, fzf = pcall(require, 'fzf-lua')
+  if not fzf_ok then
+    print("FzfLua not available")
     return
   end
   
   -- Use current_root as the search directory
-  telescope.find_files({
+  fzf.files({
     cwd = current_root,
-    prompt_title = "Find Files in " .. vim.fn.fnamemodify(current_root, ":t"),
-    hidden = config.show_hidden,
-    layout_config = {
+    winopts = {
+      title = "Find Files in " .. vim.fn.fnamemodify(current_root, ":t"),
       height = 0.8,
       width = 0.8,
     },
-    results_limit = 100,
   })
 end
 
@@ -1045,9 +1043,9 @@ function M.open(root_path)
   
   -- Override common file opening commands to prevent buffer replacement
   vim.keymap.set('n', '<leader>ff', function()
-    -- Redirect telescope to open in a proper window, not replace SimpleTree
-    local telescope_ok, telescope = pcall(require, 'telescope.builtin')
-    if telescope_ok then
+    -- Redirect fzf-lua to open in a proper window, not replace SimpleTree
+    local fzf_ok, fzf = pcall(require, 'fzf-lua')
+    if fzf_ok then
       -- Switch to a non-tree window first
       local wins = vim.api.nvim_list_wins()
       local target_win = nil
@@ -1070,7 +1068,7 @@ function M.open(root_path)
         vim.api.nvim_set_current_win(target_win)
       end
       
-      telescope.find_files()
+      fzf.files()
     end
   end, opts)
   


### PR DESCRIPTION
Replace Telescope functions with FzfLua commands to resolve "module 'telescope.builtin' not found" errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-9befaea0-4993-43e8-a0d6-8853890ea9c6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9befaea0-4993-43e8-a0d6-8853890ea9c6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>