### PR TITLE
Fix grep characters and picker esc behavior

### DIFF
--- a/lua/user/fzf-lua-fast.lua
+++ b/lua/user/fzf-lua-fast.lua
@@ -24,6 +24,8 @@ fzf_lua.setup({
         ["--no-scrollbar"] = true,
         ["--no-separator"] = true,
         ["--layout"] = "reverse",
+        ["--bind"] = "esc:abort",
+        ["--ansi"] = false,
     },
     
     -- Minimal file picker

--- a/lua/user/fzf-lua.lua
+++ b/lua/user/fzf-lua.lua
@@ -56,12 +56,13 @@ fzf_lua.setup({
             ["alt-a"] = "select-all",
             ["f3"] = "toggle-preview-wrap",
             ["f4"] = "toggle-preview",
+            ["esc"] = "abort",
         },
     },
     
     -- FZF options for performance
     fzf_opts = {
-        ["--ansi"] = true, -- Enable ANSI so ripgrep colors show in results
+        ["--ansi"] = false, -- Disable ANSI; we disable ripgrep colors to avoid escape codes
         ["--info"] = "hidden", -- Hide info for performance
         ["--height"] = "100%",
         ["--layout"] = "reverse",
@@ -70,7 +71,7 @@ fzf_lua.setup({
         ["--no-scrollbar"] = true, -- Disable scrollbar
         ["--no-separator"] = true, -- Disable separator
         ["--multi"] = true, -- Enable multi-select
-        ["--bind"] = "ctrl-q:select-all+accept", -- Ctrl+Q selects all and accepts
+        ["--bind"] = "esc:abort,ctrl-q:select-all+accept", -- Esc aborts; Ctrl+Q selects all and accepts
     },
     
 
@@ -130,7 +131,7 @@ fzf_lua.setup({
         file_icons = true,
         color_icons = true,
         -- Keep ANSI color codes for colorized results
-        rg_opts = "--column --line-number --no-heading --color=always --smart-case --max-columns=4096 -e",
+        rg_opts = "--column --line-number --no-heading --color=never --smart-case --max-columns=4096 -e",
         rg_glob = true,
         glob_flag = "--iglob",
         glob_separator = "%s%-%-",
@@ -177,7 +178,7 @@ fzf_lua.setup({
         git_icons = false,
         file_icons = true,
         color_icons = true,
-        rg_opts = "--column --line-number --no-heading --color=always --smart-case --max-columns=4096",
+        rg_opts = "--column --line-number --no-heading --color=never --smart-case --max-columns=4096",
         -- Keep ANSI color codes for colorized results
         exec_empty_query = false,
         actions = {


### PR DESCRIPTION
Disable ANSI color codes in grep output and bind Esc to close all `fzf-lua` pickers.

---
<a href="https://cursor.com/background-agent?bcId=bc-a1a511a8-341e-4c82-b387-ddd5e815e427">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a1a511a8-341e-4c82-b387-ddd5e815e427">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

