### PR TITLE
Fix and unify fzf picker behavior

### DIFF
--- a/lua/user/fzf-lua.lua
+++ b/lua/user/fzf-lua.lua
@@ -39,6 +39,14 @@ fzf_lua.setup({
         border = "rounded",
     },
     
+    -- Global fzf options that apply to ALL pickers
+    fzf_opts = {
+        ["--multi"] = true, -- Enable multi-select for all pickers
+        ["--bind"] = "ctrl-q:select-all+accept", -- Ctrl+Q selects all and accepts for quickfix
+        ["--layout"] = "reverse",
+        ["--info"] = "inline",
+    },
+    
     -- Keymaps
     keymap = {
         builtin = {
@@ -99,7 +107,10 @@ fzf_lua.setup({
         previewer = true,
         git_icons = false,
         file_icons = false,
-        color_icons = false
+        color_icons = false,
+        actions = {
+            ["ctrl-q"] = _G.fzf_send_to_quickfix,
+        },
         -- git_icons = false, -- Disable for max performance
         -- file_icons = false, -- Disable for max performance  
         -- color_icons = false, -- Disable for max performance
@@ -151,6 +162,9 @@ fzf_lua.setup({
         prompt = "Rg> ",
         -- input_prompt = "Grep For> ",
         multiprocess = true,
+        actions = {
+            ["ctrl-q"] = _G.fzf_send_to_quickfix,
+        },
     },
     --     git_icons = false,
     --     file_icons = true,
@@ -214,38 +228,7 @@ fzf_lua.setup({
         -- end,
         exec_empty_query = false,
         actions = {
-            ["enter"] = function(selected, opts)
-                -- Parse the grep result and open the file at the correct line and column
-                if #selected > 0 then
-                    local line = selected[1]
-                    -- Strip ANSI color codes first
-                    local clean_line = line:gsub("\27%[[0-9;]*m", "")
-                    
-                    -- Parse grep result format: filename:line:col:text
-                    local filename, lnum, col, text = clean_line:match("([^:]+):(%d+):(%d+):(.*)")
-                    if filename and lnum and col then
-                        -- Open the file and jump to the line and column
-                        vim.cmd("edit " .. vim.fn.fnameescape(filename))
-                        vim.api.nvim_win_set_cursor(0, {tonumber(lnum), tonumber(col) - 1})
-                    else
-                        -- Fallback: try to parse as just filename:line
-                        local fname, line_num = clean_line:match("([^:]+):(%d+):")
-                        if fname and line_num then
-                            vim.cmd("edit " .. vim.fn.fnameescape(fname))
-                            vim.api.nvim_win_set_cursor(0, {tonumber(line_num), 0})
-                        else
-                            -- Last fallback: treat as filename only
-                            local file_path = clean_line:match("^%s*(.-)%s*$") -- trim whitespace
-                            if file_path and file_path ~= "" then
-                                vim.cmd("edit " .. vim.fn.fnameescape(file_path))
-                            end
-                        end
-                    end
-                end
-            end,
-            ["ctrl-q"] = function(selected, opts)
-                _G.fzf_send_to_qf_all(selected, opts)
-            end,
+            ["ctrl-q"] = _G.fzf_send_to_quickfix,
         },
     },
     
@@ -259,9 +242,7 @@ fzf_lua.setup({
         cwd_only = false,
         previewer = true, -- Disable previewer for instant opening
         actions = {
-            ["ctrl-q"] = function(selected, opts)
-                _G.fzf_send_to_qf_all(selected, opts)
-            end,
+            ["ctrl-q"] = _G.fzf_send_to_quickfix,
         },
     },
     
@@ -279,6 +260,9 @@ fzf_lua.setup({
             git_icons = true,
             file_icons = true,
             color_icons = true,
+            actions = {
+                ["ctrl-q"] = _G.fzf_send_to_quickfix,
+            },
         },
         status = {
             prompt = "GitStatus> ",
@@ -288,6 +272,9 @@ fzf_lua.setup({
             git_icons = true,
             color_icons = true,
             previewer = "git_diff",
+            actions = {
+                ["ctrl-q"] = _G.fzf_send_to_quickfix,
+            },
         },
         commits = {
             prompt = "Commits> ",
@@ -316,10 +303,28 @@ fzf_lua.setup({
         symbols = {
             async_or_timeout = true,
             symbol_style = 1,
+            actions = {
+                ["ctrl-q"] = _G.fzf_send_to_quickfix,
+            },
         },
         code_actions = {
             prompt = "Code Actions> ",
             async_or_timeout = 5000,
+        },
+        references = {
+            actions = {
+                ["ctrl-q"] = _G.fzf_send_to_quickfix,
+            },
+        },
+        definitions = {
+            actions = {
+                ["ctrl-q"] = _G.fzf_send_to_quickfix,
+            },
+        },
+        implementations = {
+            actions = {
+                ["ctrl-q"] = _G.fzf_send_to_quickfix,
+            },
         },
     },
     
@@ -331,9 +336,7 @@ fzf_lua.setup({
         git_icons = false,
         diag_icons = true,
         actions = {
-            ["ctrl-q"] = function(selected, opts)
-                _G.fzf_send_to_qf_all(selected, opts)
-            end,
+            ["ctrl-q"] = _G.fzf_send_to_quickfix,
         },
     },
     
@@ -582,61 +585,61 @@ fzf_lua.setup({
 -- Register fzf-lua for vim.ui.select
 fzf_lua.register_ui_select()
 
--- Global function for sending ALL results to quickfix
--- How ctrl-q works now:
--- 1. The fzf_opts includes "--bind=ctrl-q:select-all+accept" which automatically
---    selects ALL items when ctrl-q is pressed and then accepts them
--- 2. This means all visible results get passed to the selected parameter
--- 3. The function below parses each item and adds it to the quickfix list
-local function send_to_qf(selected, opts)
+-- Simplified and robust quickfix function for ALL fzf pickers
+local function send_to_quickfix(selected, opts)
+    if not selected or #selected == 0 then
+        print("No items selected for quickfix")
+        return
+    end
+    
     local qf_list = {}
     
-    -- Now that we have multi-select enabled, selected should contain all items
-    print(string.format("Processing %d selected items", #selected))
-    
     for _, line in ipairs(selected) do
-        -- Strip ANSI color codes first
-        local clean_line = line:gsub("\27%[[0-9;]*m", "")
-        
-        -- Try to parse as grep result first (filename:line:col:text)
-        local filename, lnum, col, text = clean_line:match("([^:]+):(%d+):(%d+):(.*)")
-        if filename and lnum and col and text then
-            table.insert(qf_list, {
-                filename = filename,
-                lnum = tonumber(lnum),
-                col = tonumber(col),
-                text = text,
-            })
-        else
-            -- Fallback: treat as file path
-            local file_path = clean_line:match("^%s*(.-)%s*$") -- trim whitespace
-            if file_path and file_path ~= "" then
+        if line and line ~= "" then
+            -- Strip ANSI color codes
+            local clean_line = line:gsub("\27%[[0-9;]*m", "")
+            
+            -- Try different parsing patterns
+            local filename, lnum, col, text
+            
+            -- Pattern 1: grep/ripgrep format (file:line:col:text)
+            filename, lnum, col, text = clean_line:match("([^:]+):(%d+):(%d+):(.*)")
+            
+            if not filename then
+                -- Pattern 2: simple format (file:line:text)
+                filename, lnum, text = clean_line:match("([^:]+):(%d+):(.*)")
+                col = 1
+            end
+            
+            if not filename then
+                -- Pattern 3: just filename
+                filename = clean_line:match("^%s*(.-)%s*$") -- trim whitespace
+                lnum, col, text = 1, 1, "File: " .. filename
+            end
+            
+            -- Add to quickfix list if we have a valid filename
+            if filename and filename ~= "" then
                 table.insert(qf_list, {
-                    filename = file_path,
-                    lnum = 1,
-                    col = 1,
-                    text = "File: " .. file_path,
+                    filename = filename,
+                    lnum = tonumber(lnum) or 1,
+                    col = tonumber(col) or 1,
+                    text = text or filename,
                 })
             end
         end
     end
+    
     if #qf_list > 0 then
+        -- Replace quickfix list and open it
         vim.fn.setqflist(qf_list, 'r')
         vim.cmd("copen")
-        print(string.format("Sent %d items to quickfix list", #qf_list))
+        print(string.format("Added %d items to quickfix list", #qf_list))
     else
-        print("No items to send to quickfix")
+        print("No valid items to add to quickfix")
     end
 end
 
--- Function that sends all selected results to quickfix
-local function send_to_qf_all(selected, opts)
-    -- With the --bind="ctrl-q:select-all+accept" option, all items should be selected automatically
-    send_to_qf(selected, opts)
-end
-
--- Make the functions available globally
-_G.fzf_send_to_qf = send_to_qf
-_G.fzf_send_to_qf_all = send_to_qf_all
+-- Make the function available globally
+_G.fzf_send_to_quickfix = send_to_quickfix
 
 return fzf_lua


### PR DESCRIPTION
Unifies and fixes the "send to quickfix list" behavior for all fzf pickers to prevent unexpected closing and simplify configuration.

The previous implementation lacked a global binding for `ctrl-q` to automatically select all items and accept them, leading to inconsistent behavior and the quickfix list closing when switching tabs. This PR introduces a global `fzf_opts` binding for `ctrl-q:select-all+accept` and centralizes the quickfix logic into a single, robust function, ensuring consistent behavior across all fzf pickers.

---
<a href="https://cursor.com/background-agent?bcId=bc-d5ba102d-3ba9-46d5-8d36-5c23e201f561">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d5ba102d-3ba9-46d5-8d36-5c23e201f561">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

