### PR TITLE
Fix invalid window number error

### DIFF
--- a/lua/user/buffer_browser.lua
+++ b/lua/user/buffer_browser.lua
@@ -99,6 +99,7 @@ M.open_buffer_browser = function()
   
   -- Select buffer with Enter
   vim.keymap.set("n", "<CR>", function()
+    if not vim.api.nvim_win_is_valid(win) then return end
     local line = vim.api.nvim_win_get_cursor(win)[1]
     if line > 2 and line <= #buffers + 2 then
       local buffer = buffers[line - 2]
@@ -109,6 +110,7 @@ M.open_buffer_browser = function()
   
   -- Delete buffer with 'd'
   vim.keymap.set("n", "d", function()
+    if not vim.api.nvim_win_is_valid(win) then return end
     local line = vim.api.nvim_win_get_cursor(win)[1]
     if line > 2 and line <= #buffers + 2 then
       local buffer = buffers[line - 2]
@@ -121,6 +123,7 @@ M.open_buffer_browser = function()
   
   -- Split horizontally with 's'
   vim.keymap.set("n", "s", function()
+    if not vim.api.nvim_win_is_valid(win) then return end
     local line = vim.api.nvim_win_get_cursor(win)[1]
     if line > 2 and line <= #buffers + 2 then
       local buffer = buffers[line - 2]
@@ -132,6 +135,7 @@ M.open_buffer_browser = function()
   
   -- Split vertically with 'v'
   vim.keymap.set("n", "v", function()
+    if not vim.api.nvim_win_is_valid(win) then return end
     local line = vim.api.nvim_win_get_cursor(win)[1]
     if line > 2 and line <= #buffers + 2 then
       local buffer = buffers[line - 2]
@@ -292,6 +296,7 @@ M.toggle_sidebar = function()
   
   -- Select buffer with Enter
   vim.keymap.set("n", "<CR>", function()
+    if not vim.api.nvim_win_is_valid(win) then return end
     local line = vim.api.nvim_win_get_cursor(win)[1]
     if line > 5 and line <= #M._sidebar_state.buffers + 5 then
       local buffer = M._sidebar_state.buffers[line - 5]
@@ -305,6 +310,7 @@ M.toggle_sidebar = function()
   
   -- Delete buffer with 'd'
   vim.keymap.set("n", "d", function()
+    if not vim.api.nvim_win_is_valid(win) then return end
     local line = vim.api.nvim_win_get_cursor(win)[1]
     if line > 5 and line <= #M._sidebar_state.buffers + 5 then
       local buffer = M._sidebar_state.buffers[line - 5]

--- a/lua/user/coc_virtual_lines.lua
+++ b/lua/user/coc_virtual_lines.lua
@@ -65,6 +65,12 @@ local function show_virtual_lines(bufnr)
   end
   
   bufnr = bufnr or vim.api.nvim_get_current_buf()
+  
+  -- Check if buffer is valid
+  if not vim.api.nvim_buf_is_valid(bufnr) then
+    return
+  end
+  
   clear_virtual_lines(bufnr)
   
   local diagnostics = get_coc_diagnostics()
@@ -86,7 +92,13 @@ local function show_virtual_lines(bufnr)
   
   -- If current_line_only is enabled, filter to current line
   if config.current_line_only then
-    local cursor_line = vim.api.nvim_win_get_cursor(0)[1] - 1
+    -- Check if current window is valid before getting cursor position
+    local current_win = vim.api.nvim_get_current_win()
+    if not vim.api.nvim_win_is_valid(current_win) then
+      return
+    end
+    
+    local cursor_line = vim.api.nvim_win_get_cursor(current_win)[1] - 1
     local temp = {}
     if diagnostics_by_line[cursor_line] then
       temp[cursor_line] = diagnostics_by_line[cursor_line]

--- a/lua/user/diagnostics_display.lua
+++ b/lua/user/diagnostics_display.lua
@@ -76,7 +76,14 @@ local function debug_coc_diagnostics()
     print("First diagnostic structure:")
     print(vim.inspect(diagnostics[1]))
     
-    local cursor_pos = vim.api.nvim_win_get_cursor(0)
+    -- Check if current window is valid before getting cursor position
+    local current_win = vim.api.nvim_get_current_win()
+    if not vim.api.nvim_win_is_valid(current_win) then
+      print("Current window is not valid")
+      return {}
+    end
+    
+    local cursor_pos = vim.api.nvim_win_get_cursor(current_win)
     local current_line_1based = cursor_pos[1]
     local current_line_0based = cursor_pos[1] - 1
     print("Current cursor position (1-based):", current_line_1based)
@@ -151,7 +158,13 @@ local function get_coc_line_diagnostics()
     return {}
   end
   
-  local cursor_pos = vim.api.nvim_win_get_cursor(0)
+  -- Check if current window is valid before getting cursor position
+  local current_win = vim.api.nvim_get_current_win()
+  if not vim.api.nvim_win_is_valid(current_win) then
+    return {}
+  end
+  
+  local cursor_pos = vim.api.nvim_win_get_cursor(current_win)
   local current_line_1based = cursor_pos[1]
   local current_line_0based = cursor_pos[1] - 1
   
@@ -383,6 +396,11 @@ local function show_diagnostic_buffer(diagnostics, title, show_line_info)
   
   -- Helper function to navigate to diagnostic
   local function navigate_to_diagnostic()
+    -- Check if window is still valid
+    if not vim.api.nvim_win_is_valid(win) then
+      return
+    end
+    
     local cursor_line = vim.api.nvim_win_get_cursor(win)[1]
     local diagnostic = diagnostic_map[cursor_line]
     
@@ -463,7 +481,14 @@ function M.test_line_numbers()
     return
   end
   
-  local cursor_pos = vim.api.nvim_win_get_cursor(0)
+  -- Check if current window is valid before getting cursor position
+  local current_win = vim.api.nvim_get_current_win()
+  if not vim.api.nvim_win_is_valid(current_win) then
+    print("Current window is not valid")
+    return
+  end
+  
+  local cursor_pos = vim.api.nvim_win_get_cursor(current_win)
   local current_line_1based = cursor_pos[1]
   local current_line_0based = cursor_pos[1] - 1
   

--- a/lua/user/lualine.lua
+++ b/lua/user/lualine.lua
@@ -420,7 +420,13 @@ lualine.setup {
                         node = ts_utils.get_node_at_cursor()
                     else
                         -- Use newer API if available
-                        local cursor = vim.api.nvim_win_get_cursor(0)
+                        -- Check if current window is valid before getting cursor position
+                        local current_win = vim.api.nvim_get_current_win()
+                        if not vim.api.nvim_win_is_valid(current_win) then
+                            return ''
+                        end
+                        
+                        local cursor = vim.api.nvim_win_get_cursor(current_win)
                         local row, col = cursor[1] - 1, cursor[2]
                         local ok_parser, parser = pcall(vim.treesitter.get_parser, 0)
                         if not ok_parser or not parser then return '' end

--- a/lua/user/simple_tree.lua
+++ b/lua/user/simple_tree.lua
@@ -750,6 +750,12 @@ local function show_context_menu()
     vim.api.nvim_buf_set_lines(menu_buf, 0, -1, false, menu_items)
     vim.api.nvim_buf_set_option(menu_buf, 'modifiable', false)
     vim.api.nvim_buf_set_option(menu_buf, 'buftype', 'nofile')
+    
+    -- Validate tree window before getting cursor
+    if not tree_win or not vim.api.nvim_win_is_valid(tree_win) then
+        return
+    end
+    
     local cursor = vim.api.nvim_win_get_cursor(tree_win)
     local width = 25
     local height = #menu_items
@@ -785,6 +791,7 @@ local function show_context_menu()
         end
     end
     local function execute_action()
+        if not vim.api.nvim_win_is_valid(menu_win) then return end
         local menu_cursor = vim.api.nvim_win_get_cursor(menu_win)
         local selected_idx = menu_cursor[1]
         local action = menu_actions[selected_idx]
@@ -792,6 +799,7 @@ local function show_context_menu()
         if action then action() end
     end
     local function move_to_next_valid_item(direction)
+        if not vim.api.nvim_win_is_valid(menu_win) then return end
         local menu_cursor = vim.api.nvim_win_get_cursor(menu_win)
         local current_idx = menu_cursor[1]
         local next_idx = current_idx


### PR DESCRIPTION
Prevent "E957: Invalid window number" errors by adding window validity checks before accessing window cursor positions.

The error occurred when `CursorMoved` autocommands or other functions attempted to retrieve cursor positions from windows that were no longer valid (e.g., during buffer switches or window closures). This PR adds `vim.api.nvim_win_is_valid()` checks before `nvim_win_get_cursor` calls across several files to ensure operations only proceed on active windows.

---
<a href="https://cursor.com/background-agent?bcId=bc-49c4b518-8bce-417c-b054-a62dcaf13e71">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-49c4b518-8bce-417c-b054-a62dcaf13e71">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

