### PR TITLE
Find and fix bugs

### DIFF
--- a/lua/user/terminal.lua
+++ b/lua/user/terminal.lua
@@ -33,10 +33,6 @@ local function configure_terminal_buffer(buf)
   local success = true
   
   success = success and pcall(function()
-    vim.api.nvim_buf_set_option(buf, "buftype", "terminal")
-  end)
-  
-  success = success and pcall(function()
     vim.api.nvim_buf_set_option(buf, "modifiable", true)
   end)
   

--- a/test_terminal_fix.lua
+++ b/test_terminal_fix.lua
@@ -1,6 +1,8 @@
 -- Test script to verify terminal fix
 -- This script tests the horizontal terminal creation to ensure no treesitter errors
 
+require("user.terminal")
+
 print("Testing horizontal terminal creation...")
 
 -- Simulate the terminal creation process
@@ -8,16 +10,18 @@ local function test_horizontal_terminal()
   -- Create a split
   vim.cmd("split")
   
-  -- Get the buffer
-  local buf = vim.api.nvim_get_current_buf()
+  -- Create a scratch buffer and set it in the split (matches implementation)
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_set_current_buf(buf)
   
-  -- Set buffer options (like in our fix)
-  vim.api.nvim_buf_set_option(buf, "buftype", "terminal")
-  vim.api.nvim_buf_set_option(buf, "modifiable", true)
-  vim.api.nvim_buf_set_option(buf, "swapfile", false)
+  -- Configure buffer safely using helper
+  local ok = configure_terminal_buffer(buf)
+  if not ok then
+    error("configure_terminal_buffer failed")
+  end
   
-  -- Disable syntax highlighting
-  vim.api.nvim_buf_set_option(buf, "syntax", "")
+  -- Disable treesitter/syntax safely using helper
+  disable_treesitter_for_terminal(buf)
   
   print("Buffer configured as terminal type")
   print("Treesitter highlighting disabled")

--- a/test_terminal_safety.lua
+++ b/test_terminal_safety.lua
@@ -1,4 +1,5 @@
 -- Test script to verify terminal safety functions
+require("user.terminal")
 print("Testing terminal safety functions...")
 
 -- Test the configure_terminal_buffer function


### PR DESCRIPTION
Remove redundant `buftype` setting from terminal configuration and update tests to correctly use terminal helpers.

---
<a href="https://cursor.com/background-agent?bcId=bc-0e276b34-7c79-4915-bfa2-5f51ff09163a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0e276b34-7c79-4915-bfa2-5f51ff09163a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

