### PR TITLE
Fix ctrl+d scrolling issue

### DIFF
--- a/lua/user/fzf-lua.lua
+++ b/lua/user/fzf-lua.lua
@@ -54,7 +54,7 @@ fzf_lua.setup({
             ["<F2>"] = "toggle-fullscreen",
             ["<F3>"] = "toggle-preview-wrap",
             ["<F4>"] = "toggle-preview",
-            ["<C-d>"] = "preview-page-down",
+            -- ["<C-d>"] = "preview-page-down", -- Removed to restore default Neovim scroll behavior
             ["<C-u>"] = "preview-page-up",
         },
         fzf = {


### PR DESCRIPTION
Remove FzfLua override for Ctrl+D to restore default Neovim scroll behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-5b12ec16-eb5d-46d3-86e5-cee95a41604c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5b12ec16-eb5d-46d3-86e5-cee95a41604c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

