### PR TITLE
Update lsp diagnostic commands for vim.lsp

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -42,7 +42,7 @@ require "user.colorizer"
 require "user.functions"
 require "user.surround"
 require "user.nvim_transparent"
-require "user.diagnostics_display"
+require("user.diagnostics_display").setup()
 require "user.buffer_navigation"
 
 -- fzf-lua is now loaded via lazy.nvim
@@ -66,6 +66,7 @@ vim.keymap.set(
 -- require("goto-preview").setup {} -- Now configured via goto_preview_lsp.lua
 -- require("neogit").setup {} -- Now lazy loaded
 -- telescope extensions replaced with fzf-lua
-vim.diagnostic.config { virtual_lines = true }
+-- Diagnostic config is now handled by lsp.lua and diagnostics_display.lua
+-- vim.diagnostic.config { virtual_lines = true }
 vim.fn.sign_define("LspCodeAction", { text = "", texthl = "", linehl = "", numhl = "" })
 vim.fn.sign_define("LspCodeActionAvailable", { text = "", texthl = "", linehl = "", numhl = "" })

--- a/lua/user/diagnostics_display.lua
+++ b/lua/user/diagnostics_display.lua
@@ -1,78 +1,15 @@
 local M = {}
 
--- Track the diagnostic floating window
-local diagnostic_win_id = nil
-
 -- Simple diagnostic display using native vim.diagnostic functions
--- Compatible with vim.lsp
+-- Compatible with vim.lsp - works just like K (vim.lsp.buf.hover)
 
--- Show line diagnostics using native vim.diagnostic.open_float
--- Toggle-able and focusable for interaction
+-- Show line diagnostics - simple implementation like vim.lsp.buf.hover
 function M.show_line_diagnostics()
-  -- If window is already open, focus it or close it
-  if diagnostic_win_id and vim.api.nvim_win_is_valid(diagnostic_win_id) then
-    -- If we're already in the diagnostic window, close it
-    if vim.api.nvim_get_current_win() == diagnostic_win_id then
-      vim.api.nvim_win_close(diagnostic_win_id, false)
-      diagnostic_win_id = nil
-      return
-    else
-      -- Focus the existing window
-      vim.api.nvim_set_current_win(diagnostic_win_id)
-      return
-    end
-  end
-  
-  -- Check if there are diagnostics on current line
-  local line = vim.fn.line('.') - 1
-  local diagnostics = vim.diagnostic.get(0, { lnum = line })
-  
-  if #diagnostics == 0 then
-    vim.notify("No diagnostics on current line", vim.log.levels.INFO)
-    return
-  end
-  
-  -- Open new floating window
-  local float_win, _ = vim.diagnostic.open_float(nil, {
+  vim.diagnostic.open_float(nil, {
     border = "rounded",
     source = "always",
-    prefix = " ",
-    scope = "cursor",
-    focusable = true,  -- Make it focusable
-    focus = true,      -- Focus it immediately
-    close_events = { "BufLeave" }, -- Only close on buffer leave, not cursor move
+    focusable = true,  -- This allows focusing the window on second press
   })
-  
-  -- Store the window ID for toggling
-  diagnostic_win_id = float_win
-  
-  -- Set up keymaps for the floating window
-  if float_win and vim.api.nvim_win_is_valid(float_win) then
-    local buf = vim.api.nvim_win_get_buf(float_win)
-    -- Close with Escape or q
-    vim.keymap.set('n', '<Esc>', function()
-      if vim.api.nvim_win_is_valid(diagnostic_win_id) then
-        vim.api.nvim_win_close(diagnostic_win_id, false)
-        diagnostic_win_id = nil
-      end
-    end, { buffer = buf, silent = true })
-    
-    vim.keymap.set('n', 'q', function()
-      if vim.api.nvim_win_is_valid(diagnostic_win_id) then
-        vim.api.nvim_win_close(diagnostic_win_id, false)
-        diagnostic_win_id = nil
-      end
-    end, { buffer = buf, silent = true })
-    
-    -- Clear the stored window ID when window is closed
-    vim.api.nvim_create_autocmd("WinClosed", {
-      pattern = tostring(float_win),
-      callback = function()
-        diagnostic_win_id = nil
-      end,
-      once = true,
-    })
-  end
 end
 
 -- Show file diagnostics using quickfix list
@@ -146,22 +83,9 @@ function M.setup()
       source = "always",
       header = "",
       prefix = "",
+      focusable = true,  -- Make all diagnostic floats focusable by default
     },
   })
-  
-  -- Optional: Auto-show diagnostics on cursor hold (uncomment if desired)
-  -- vim.api.nvim_create_autocmd("CursorHold", {
-  --   callback = function()
-  --     vim.diagnostic.open_float(nil, {
-  --       focusable = false,
-  --       close_events = { "BufLeave", "CursorMoved", "InsertEnter", "FocusLost" },
-  --       border = "rounded",
-  --       source = "always",
-  --       prefix = " ",
-  --       scope = "cursor",
-  --     })
-  --   end,
-  -- })
 end
 
 return M

--- a/lua/user/diagnostics_display.lua
+++ b/lua/user/diagnostics_display.lua
@@ -1,18 +1,78 @@
 local M = {}
 
+-- Track the diagnostic floating window
+local diagnostic_win_id = nil
+
 -- Simple diagnostic display using native vim.diagnostic functions
 -- Compatible with vim.lsp
 
 -- Show line diagnostics using native vim.diagnostic.open_float
+-- Toggle-able and focusable for interaction
 function M.show_line_diagnostics()
-  vim.diagnostic.open_float(nil, {
+  -- If window is already open, focus it or close it
+  if diagnostic_win_id and vim.api.nvim_win_is_valid(diagnostic_win_id) then
+    -- If we're already in the diagnostic window, close it
+    if vim.api.nvim_get_current_win() == diagnostic_win_id then
+      vim.api.nvim_win_close(diagnostic_win_id, false)
+      diagnostic_win_id = nil
+      return
+    else
+      -- Focus the existing window
+      vim.api.nvim_set_current_win(diagnostic_win_id)
+      return
+    end
+  end
+  
+  -- Check if there are diagnostics on current line
+  local line = vim.fn.line('.') - 1
+  local diagnostics = vim.diagnostic.get(0, { lnum = line })
+  
+  if #diagnostics == 0 then
+    vim.notify("No diagnostics on current line", vim.log.levels.INFO)
+    return
+  end
+  
+  -- Open new floating window
+  local float_win, _ = vim.diagnostic.open_float(nil, {
     border = "rounded",
     source = "always",
     prefix = " ",
     scope = "cursor",
-    focusable = false,
-    close_events = { "BufLeave", "CursorMoved", "InsertEnter", "FocusLost" },
+    focusable = true,  -- Make it focusable
+    focus = true,      -- Focus it immediately
+    close_events = { "BufLeave" }, -- Only close on buffer leave, not cursor move
   })
+  
+  -- Store the window ID for toggling
+  diagnostic_win_id = float_win
+  
+  -- Set up keymaps for the floating window
+  if float_win and vim.api.nvim_win_is_valid(float_win) then
+    local buf = vim.api.nvim_win_get_buf(float_win)
+    -- Close with Escape or q
+    vim.keymap.set('n', '<Esc>', function()
+      if vim.api.nvim_win_is_valid(diagnostic_win_id) then
+        vim.api.nvim_win_close(diagnostic_win_id, false)
+        diagnostic_win_id = nil
+      end
+    end, { buffer = buf, silent = true })
+    
+    vim.keymap.set('n', 'q', function()
+      if vim.api.nvim_win_is_valid(diagnostic_win_id) then
+        vim.api.nvim_win_close(diagnostic_win_id, false)
+        diagnostic_win_id = nil
+      end
+    end, { buffer = buf, silent = true })
+    
+    -- Clear the stored window ID when window is closed
+    vim.api.nvim_create_autocmd("WinClosed", {
+      pattern = tostring(float_win),
+      callback = function()
+        diagnostic_win_id = nil
+      end,
+      once = true,
+    })
+  end
 end
 
 -- Show file diagnostics using quickfix list

--- a/lua/user/diagnostics_display.lua
+++ b/lua/user/diagnostics_display.lua
@@ -245,11 +245,8 @@ function M.setup()
     },
   }
 
-  -- Keymaps
-  vim.keymap.set("n", "<leader>dl", M.show_line_diagnostics, { desc = "Show line diagnostics" })
-  vim.keymap.set("n", "<leader>df", M.show_file_diagnostics, { desc = "Show file diagnostics" })
-  vim.keymap.set("n", "<leader>dw", M.show_workspace_diagnostics, { desc = "Show workspace diagnostics" })
-
+  -- Keymaps are handled in keymaps.lua to avoid conflicts
+  
   -- Auto-show diagnostics on cursor hold
   vim.api.nvim_create_autocmd("CursorHold", {
     callback = function()

--- a/lua/user/diagnostics_display.lua
+++ b/lua/user/diagnostics_display.lua
@@ -1,266 +1,107 @@
 local M = {}
 
-local icons = require "user.icons"
+-- Simple diagnostic display using native vim.diagnostic functions
+-- Compatible with vim.lsp
 
--- Configuration
-local config = {
-  border = "rounded",
-  width = 80,
-  height = 20,
-  title_current_line = "  Current Line Diagnostics (LSP)",
-  title_current_file = "  Current File Diagnostics (LSP)",
-  max_width = 120,
-  max_height = 30,
-}
-
--- Native LSP diagnostic severity mapping
-local severity_map = {
-  [vim.diagnostic.severity.ERROR] = {
-    icon = icons.diagnostics.Error,
-    name = "Error",
-    hl = "DiagnosticError",
-  },
-  [vim.diagnostic.severity.WARN] = {
-    icon = icons.diagnostics.Warning,
-    name = "Warning",
-    hl = "DiagnosticWarn",
-  },
-  [vim.diagnostic.severity.INFO] = {
-    icon = icons.diagnostics.Information,
-    name = "Info",
-    hl = "DiagnosticInfo",
-  },
-  [vim.diagnostic.severity.HINT] = {
-    icon = icons.diagnostics.Hint,
-    name = "Hint",
-    hl = "DiagnosticHint",
-  },
-}
-
--- Create floating window for diagnostics
-local function create_float_win(content, title)
-  local buf = vim.api.nvim_create_buf(false, true)
-
-  -- Set content
-  vim.api.nvim_buf_set_lines(buf, 0, -1, false, content)
-
-  -- Calculate window size
-  local width = math.min(config.max_width, math.max(config.width, vim.fn.max(vim.fn.map(content, "len(v:val)"))))
-  local height = math.min(config.max_height, math.max(config.height, #content))
-
-  -- Center the window
-  local row = math.floor((vim.o.lines - height) / 2)
-  local col = math.floor((vim.o.columns - width) / 2)
-
-  local win_opts = {
-    relative = "editor",
-    row = row,
-    col = col,
-    width = width,
-    height = height,
-    border = config.border,
-    title = title,
-    title_pos = "center",
-    style = "minimal",
-  }
-
-  local win = vim.api.nvim_open_win(buf, true, win_opts)
-
-  -- Set buffer options
-  vim.api.nvim_buf_set_option(buf, "bufhidden", "wipe")
-  vim.api.nvim_buf_set_option(buf, "filetype", "diagnostics")
-  vim.api.nvim_buf_set_option(buf, "modifiable", false)
-
-  -- Close on escape
-  vim.keymap.set("n", "<Esc>", "<cmd>close<cr>", { buffer = buf, silent = true })
-  vim.keymap.set("n", "q", "<cmd>close<cr>", { buffer = buf, silent = true })
-
-  return win, buf
-end
-
--- Format diagnostic for display
-local function format_diagnostic(diagnostic, line_num)
-  local severity_info = severity_map[diagnostic.severity] or severity_map[vim.diagnostic.severity.ERROR]
-  local source = diagnostic.source and string.format(" [%s]", diagnostic.source) or ""
-  local code = diagnostic.code and string.format(" (%s)", diagnostic.code) or ""
-
-  return string.format("%s %s: %s%s%s", severity_info.icon, severity_info.name, diagnostic.message, code, source)
-end
-
--- Show current line diagnostics
+-- Show line diagnostics using native vim.diagnostic.open_float
 function M.show_line_diagnostics()
-  local line = vim.fn.line "." - 1
-  local diagnostics = vim.diagnostic.get(0, { lnum = line })
-
-  if #diagnostics == 0 then
-    vim.notify("No diagnostics on current line", vim.log.levels.INFO)
-    return
-  end
-
-  local content = {}
-  table.insert(content, string.format("Line %d:", line + 1))
-  table.insert(content, "")
-
-  for _, diagnostic in ipairs(diagnostics) do
-    table.insert(content, format_diagnostic(diagnostic, line + 1))
-  end
-
-  create_float_win(content, config.title_current_line)
+  vim.diagnostic.open_float(nil, {
+    border = "rounded",
+    source = "always",
+    prefix = " ",
+    scope = "cursor",
+    focusable = false,
+    close_events = { "BufLeave", "CursorMoved", "InsertEnter", "FocusLost" },
+  })
 end
 
--- Show current file diagnostics
+-- Show file diagnostics using quickfix list
 function M.show_file_diagnostics()
-  local diagnostics = vim.diagnostic.get(0)
-
+  local diagnostics = vim.diagnostic.get(0) -- Current buffer only
+  
   if #diagnostics == 0 then
     vim.notify("No diagnostics in current file", vim.log.levels.INFO)
     return
   end
-
-  local content = {}
-  table.insert(content, string.format("File: %s", vim.fn.expand "%:t"))
-  table.insert(content, string.format("Total diagnostics: %d", #diagnostics))
-  table.insert(content, "")
-
-  -- Group diagnostics by line
-  local by_line = {}
+  
+  -- Convert diagnostics to quickfix format
+  local qf_list = {}
   for _, diagnostic in ipairs(diagnostics) do
-    local line = diagnostic.lnum + 1
-    if not by_line[line] then by_line[line] = {} end
-    table.insert(by_line[line], diagnostic)
+    table.insert(qf_list, {
+      bufnr = diagnostic.bufnr or 0,
+      lnum = diagnostic.lnum + 1, -- Convert to 1-based
+      col = diagnostic.col + 1,   -- Convert to 1-based
+      text = diagnostic.message,
+      type = diagnostic.severity == vim.diagnostic.severity.ERROR and "E" or
+             diagnostic.severity == vim.diagnostic.severity.WARN and "W" or
+             diagnostic.severity == vim.diagnostic.severity.INFO and "I" or "H"
+    })
   end
-
-  -- Sort lines
-  local lines = {}
-  for line, _ in pairs(by_line) do
-    table.insert(lines, line)
-  end
-  table.sort(lines)
-
-  -- Format output
-  for _, line in ipairs(lines) do
-    table.insert(content, string.format("Line %d:", line))
-    for _, diagnostic in ipairs(by_line[line]) do
-      table.insert(content, "  " .. format_diagnostic(diagnostic, line))
-    end
-    table.insert(content, "")
-  end
-
-  create_float_win(content, config.title_current_file)
+  
+  vim.fn.setqflist(qf_list, "r")
+  vim.cmd("copen")
+  vim.notify(string.format("Found %d diagnostics in current file", #diagnostics), vim.log.levels.INFO)
 end
 
--- Show workspace diagnostics
+-- Show workspace diagnostics using quickfix list
 function M.show_workspace_diagnostics()
-  local diagnostics = vim.diagnostic.get()
-
+  local diagnostics = vim.diagnostic.get() -- All buffers
+  
   if #diagnostics == 0 then
     vim.notify("No diagnostics in workspace", vim.log.levels.INFO)
     return
   end
-
-  local content = {}
-  table.insert(content, "Workspace Diagnostics")
-  table.insert(content, string.format("Total diagnostics: %d", #diagnostics))
-  table.insert(content, "")
-
-  -- Group by file
-  local by_file = {}
+  
+  -- Convert diagnostics to quickfix format
+  local qf_list = {}
   for _, diagnostic in ipairs(diagnostics) do
-    local bufnr = diagnostic.bufnr or 0
-    local filename = vim.api.nvim_buf_get_name(bufnr)
-    filename = vim.fn.fnamemodify(filename, ":.")
-
-    if not by_file[filename] then by_file[filename] = {} end
-    table.insert(by_file[filename], diagnostic)
+    local filename = vim.api.nvim_buf_get_name(diagnostic.bufnr or 0)
+    table.insert(qf_list, {
+      filename = filename,
+      lnum = diagnostic.lnum + 1, -- Convert to 1-based
+      col = diagnostic.col + 1,   -- Convert to 1-based
+      text = diagnostic.message,
+      type = diagnostic.severity == vim.diagnostic.severity.ERROR and "E" or
+             diagnostic.severity == vim.diagnostic.severity.WARN and "W" or
+             diagnostic.severity == vim.diagnostic.severity.INFO and "I" or "H"
+    })
   end
-
-  -- Sort files
-  local files = {}
-  for file, _ in pairs(by_file) do
-    table.insert(files, file)
-  end
-  table.sort(files)
-
-  -- Format output
-  for _, file in ipairs(files) do
-    table.insert(content, string.format("%s (%d):", file, #by_file[file]))
-
-    -- Sort diagnostics by line
-    table.sort(by_file[file], function(a, b) return a.lnum < b.lnum end)
-
-    for _, diagnostic in ipairs(by_file[file]) do
-      table.insert(
-        content,
-        string.format("  L%d: %s", diagnostic.lnum + 1, format_diagnostic(diagnostic, diagnostic.lnum + 1))
-      )
-    end
-    table.insert(content, "")
-  end
-
-  create_float_win(content, "  Workspace Diagnostics (LSP)")
+  
+  vim.fn.setqflist(qf_list, "r")
+  vim.cmd("copen")
+  vim.notify(string.format("Found %d diagnostics in workspace", #diagnostics), vim.log.levels.INFO)
 end
 
--- Get diagnostic counts
-function M.get_diagnostic_counts(bufnr)
-  bufnr = bufnr or 0
-  local diagnostics = vim.diagnostic.get(bufnr)
-
-  local counts = {
-    error = 0,
-    warning = 0,
-    info = 0,
-    hint = 0,
-    total = #diagnostics,
-  }
-
-  for _, diagnostic in ipairs(diagnostics) do
-    if diagnostic.severity == vim.diagnostic.severity.ERROR then
-      counts.error = counts.error + 1
-    elseif diagnostic.severity == vim.diagnostic.severity.WARN then
-      counts.warning = counts.warning + 1
-    elseif diagnostic.severity == vim.diagnostic.severity.INFO then
-      counts.info = counts.info + 1
-    elseif diagnostic.severity == vim.diagnostic.severity.HINT then
-      counts.hint = counts.hint + 1
-    end
-  end
-
-  return counts
-end
-
--- Setup diagnostic display
+-- Setup function to configure diagnostics
 function M.setup()
   -- Configure diagnostic display
-  vim.diagnostic.config {
-    virtual_text = false, -- We handle this in LSP config
+  vim.diagnostic.config({
+    virtual_text = false, -- Disable inline virtual text for cleaner display
     signs = true,
     underline = true,
     update_in_insert = false,
     severity_sort = true,
     float = {
-      border = config.border,
+      border = "rounded",
       source = "always",
       header = "",
       prefix = "",
     },
-  }
-
-  -- Keymaps are handled in keymaps.lua to avoid conflicts
-  
-  -- Auto-show diagnostics on cursor hold
-  vim.api.nvim_create_autocmd("CursorHold", {
-    callback = function()
-      local opts = {
-        focusable = false,
-        close_events = { "BufLeave", "CursorMoved", "InsertEnter", "FocusLost" },
-        border = config.border,
-        source = "always",
-        prefix = " ",
-        scope = "cursor",
-      }
-      vim.diagnostic.open_float(nil, opts)
-    end,
   })
+  
+  -- Optional: Auto-show diagnostics on cursor hold (uncomment if desired)
+  -- vim.api.nvim_create_autocmd("CursorHold", {
+  --   callback = function()
+  --     vim.diagnostic.open_float(nil, {
+  --       focusable = false,
+  --       close_events = { "BufLeave", "CursorMoved", "InsertEnter", "FocusLost" },
+  --       border = "rounded",
+  --       source = "always",
+  --       prefix = " ",
+  --       scope = "cursor",
+  --     })
+  --   end,
+  -- })
 end
 
 return M

--- a/lua/user/whichkey.lua
+++ b/lua/user/whichkey.lua
@@ -350,18 +350,23 @@ which_key.add {
   -- Diagnostics
   {
     "<leader>dl",
-    "<cmd>lua require('user.diagnostics_display').show_current_line_diagnostics()<cr>",
+    "<cmd>lua require('user.diagnostics_display').show_line_diagnostics()<cr>",
     desc = "Line Diagnostics",
   },
   {
     "<leader>df",
-    "<cmd>lua require('user.diagnostics_display').show_current_file_diagnostics()<cr>",
+    "<cmd>lua require('user.diagnostics_display').show_file_diagnostics()<cr>",
     desc = "File Diagnostics",
   },
   {
     "<leader>dd",
     "<cmd>lua require('user.diagnostics_display').debug()<cr>",
     desc = "Debug Diagnostics",
+  },
+  {
+    "<leader>dw",
+    "<cmd>lua require('user.diagnostics_display').show_workspace_diagnostics()<cr>",
+    desc = "Workspace Diagnostics",
   },
 
   -- Git


### PR DESCRIPTION
Fix `<leader>dl`, `<leader>df`, and `<leader>dw` diagnostic commands for `vim.lsp` by harmonizing function calls and resolving configuration conflicts.

---
<a href="https://cursor.com/background-agent?bcId=bc-f6e4621e-8b26-4eb6-8c42-fe4703c9449d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f6e4621e-8b26-4eb6-8c42-fe4703c9449d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

